### PR TITLE
Feature/image compression augmentation

### DIFF
--- a/horizon/transforms.py
+++ b/horizon/transforms.py
@@ -89,7 +89,7 @@ def horizon_augment_ir16bit(imgsz: int) -> A.Compose:
         [
             # image transforms (16-bit compatible)
             A16.Clip(p=1.0, lower_limit=(0.2, 0.25), upper_limit=(0.4, 0.45)),
-            A16.CLAHE(p=0.5, clip_limit=(3, 5), tile_grid_size=(-1, -1)),
+            A16.CLAHE(p=0.5, clip_limit=(3, 5), tile_grid_size=(0, 0)),
             A16.NormalizeMinMax(p=1.0),
             A.UnsharpMask(p=0.5, threshold=5),
             A.ToRGB(p=1.0),
@@ -129,7 +129,7 @@ def horizon_base_ir16bit(
         [
             # image transforms (16-bit compatible)
             A16.Clip(p=1.0, lower_limit=(lower_limit,) * 2, upper_limit=(upper_limit,) * 2),
-            A16.CLAHE(p=1.0 if clahe else 0.0, clip_limit=(4, 4), tile_grid_size=(-1, -1)),
+            A16.CLAHE(p=1.0 if clahe else 0.0, clip_limit=(4, 4), tile_grid_size=(0, 0)),
             A16.NormalizeMinMax(p=1.0),
             A.UnsharpMask(p=1.0 if unsharp_mask else 0.0, threshold=5),
             A.ToRGB(p=1.0),

--- a/utils/albumentations16.py
+++ b/utils/albumentations16.py
@@ -1,15 +1,19 @@
 import random
-from typing import Sequence, Union
+from typing import Sequence, Union, Tuple, cast
 
 import albumentations as A
 import cv2
 import numpy as np
-from albumentations.core.transforms_interface import ImageOnlyTransform
-try:
-    from albumentations.core.transforms_interface import to_tuple
-except ImportError:
-    from albumentations.core.utils import to_tuple
+from albumentations.core.transforms_interface import (
+    ImageOnlyTransform,
+    BaseTransformInitSchema,
+)
 
+from albumentations.core.pydantic import (
+    NonNegativeFloatRangeType,
+    OnePlusFloatRangeType,
+    ZeroOneRangeType,
+)
 
 def convert_16bit_to_8bit(im, augment=True):
     if len(im.shape) == 3 and im.shape[2] == 3:
@@ -26,7 +30,7 @@ def get_16_to_8_transform(augment):
             [
                 # 15000/65535 = 0.228, 28000/65535 = 0.427
                 Clip(p=1.0, lower_limit=(0.2, 0.25), upper_limit=(0.4, 0.45)),
-                CLAHE(p=0.5, clip_limit=(3, 5), tile_grid_size=(-1, -1)),
+                CLAHE(p=0.5, clip_limit=(3, 5), tile_grid_size=(0, 0)),
                 NormalizeMinMax(p=1.0),
                 A.UnsharpMask(p=0.5, threshold=5),
                 A.ToRGB(p=1.0),
@@ -39,7 +43,7 @@ def get_16_to_8_transform(augment):
         return A.Compose(
             [
                 Clip(p=1.0, lower_limit=(llimit, llimit), upper_limit=(ulimit, ulimit)),
-                CLAHE(p=0.0, clip_limit=(4, 4), tile_grid_size=(-1, -1)),
+                CLAHE(p=0.0, clip_limit=(4, 4), tile_grid_size=(0, 0)),
                 NormalizeMinMax(p=1.0),
                 A.UnsharpMask(p=0.0, threshold=5),
                 A.ToRGB(p=1.0),
@@ -55,7 +59,7 @@ class CLAHE(ImageOnlyTransform):
         clip_limit (float or (float, float)): upper threshold value for contrast limiting.
             If clip_limit is a single float value, the range will be (1, clip_limit). Default: (1, 4).
         tile_grid_size ((int, int)): size of grid for histogram equalization. Default: (8, 8).
-            If (-1, -1), optimal value will be calculated based on image size.
+            If (0, 0), optimal value will be calculated based on image size.
         p (float): probability of applying the transform. Default: 0.5.
 
     Targets:
@@ -65,6 +69,10 @@ class CLAHE(ImageOnlyTransform):
         uint8, uint16
     """
 
+    class InitSchema(BaseTransformInitSchema):
+        clip_limit: OnePlusFloatRangeType = (1.0, 4.0)
+        tile_grid_size: NonNegativeFloatRangeType = (8, 8)
+
     def __init__(
         self,
         clip_limit: Union[float, Sequence[float]] = 4.0,
@@ -72,12 +80,12 @@ class CLAHE(ImageOnlyTransform):
         always_apply=False,
         p=0.5,
     ):
-        super(CLAHE, self).__init__(always_apply, p)
-        self.clip_limit = to_tuple(clip_limit, 1)
-        self.tile_grid_size = tuple(tile_grid_size)
+        super().__init__(p=p, always_apply=always_apply)
+        self.clip_limit = cast(Tuple[float, float], clip_limit)
+        self.tile_grid_size = cast(Tuple[int, int], tile_grid_size)
 
     def apply(self, img, clip_limit=2, **params):
-        if self.tile_grid_size == (-1, -1):
+        if self.tile_grid_size == (0, 0):
             # compute tile_grid_size based on image size
             tile_grid_size = (round(max(img.shape) / 160),) * 2
         else:
@@ -104,7 +112,7 @@ class NormalizeMinMax(ImageOnlyTransform):
     """
 
     def __init__(self, always_apply=False, p=0.5):
-        super(NormalizeMinMax, self).__init__(always_apply, p)
+        super().__init__(p=p, always_apply=always_apply)
 
     def apply(self, img, **params):
         return cv2.normalize(img, None, 0, 255, cv2.NORM_MINMAX, cv2.CV_8U)
@@ -127,6 +135,10 @@ class Clip(ImageOnlyTransform):
         uint8, uint16
     """
 
+    class InitSchema(BaseTransformInitSchema):
+        lower_limit: ZeroOneRangeType = (0.1, 0.2)
+        upper_limit: ZeroOneRangeType = (0.8, 0.9)
+
     def __init__(
         self,
         lower_limit: Union[float, Sequence[float]] = (0.1, 0.2),
@@ -134,9 +146,9 @@ class Clip(ImageOnlyTransform):
         always_apply=False,
         p=0.5,
     ):
-        super(Clip, self).__init__(always_apply, p)
-        self.lower_limit = to_tuple(lower_limit, 0)
-        self.upper_limit = to_tuple(upper_limit, 1)
+        super().__init__(p=p, always_apply=always_apply)
+        self.lower_limit = cast(Tuple[float, float], lower_limit)
+        self.upper_limit = cast(Tuple[float, float], upper_limit)
 
     def apply(self, img, lower_limit=0.1, upper_limit=0.9, **params):
         max_val = np.iinfo(img.dtype).max

--- a/utils/albumextensions.py
+++ b/utils/albumextensions.py
@@ -1,7 +1,7 @@
 """Custom augmentations following the Albumentations API."""
 
 import random
-from typing import Dict, Sequence, Tuple, Union
+from typing import Dict, Tuple
 
 import cv2
 import numpy as np
@@ -11,7 +11,7 @@ from albumentations.core.transforms_interface import (
     DualTransform,
     KeypointInternalType,
 )
-
+from albumentations.augmentations.geometric.resize import MaxSizeInitSchema
 
 class ResizeIfNeeded(DualTransform):
     """
@@ -29,15 +29,17 @@ class ResizeIfNeeded(DualTransform):
     Image types:
         uint8, float32
     """
+    class InitSchema(MaxSizeInitSchema):
+        pass
 
     def __init__(
         self,
-        max_size: Union[int, Sequence[int]] = 1024,
+        max_size: int | None = 1024,
         interpolation: int = cv2.INTER_LINEAR,
         always_apply: bool = False,
         p: float = 1,
     ):
-        super(ResizeIfNeeded, self).__init__(always_apply, p)
+        super().__init__(p=p, always_apply=always_apply)
         self.interpolation = interpolation
         self.max_size = max_size
 

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -38,7 +38,7 @@ class Albumentations:
                 A.CLAHE(p=0.01),
                 A.RandomBrightnessContrast(p=0.0),
                 A.RandomGamma(p=0.0),
-                A.ImageCompression(quality_lower=75, p=0.0),
+                A.ImageCompression(quality_lower=75, p=0.25),
             ]  # transforms
             self.transform = A.Compose(T, bbox_params=A.BboxParams(format="yolo", label_fields=["class_labels"]))
 

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -38,7 +38,7 @@ class Albumentations:
                 A.CLAHE(p=0.01),
                 A.RandomBrightnessContrast(p=0.0),
                 A.RandomGamma(p=0.0),
-                A.ImageCompression(quality_lower=75, p=0.75),
+                A.ImageCompression(quality_lower=50, p=0.90),
             ]  # transforms
             self.transform = A.Compose(T, bbox_params=A.BboxParams(format="yolo", label_fields=["class_labels"]))
 

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -38,7 +38,7 @@ class Albumentations:
                 A.CLAHE(p=0.01),
                 A.RandomBrightnessContrast(p=0.0),
                 A.RandomGamma(p=0.0),
-                A.ImageCompression(quality_lower=75, p=0.25),
+                A.ImageCompression(quality_lower=50, p=0.9),
             ]  # transforms
             self.transform = A.Compose(T, bbox_params=A.BboxParams(format="yolo", label_fields=["class_labels"]))
 

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -38,7 +38,7 @@ class Albumentations:
                 A.CLAHE(p=0.01),
                 A.RandomBrightnessContrast(p=0.0),
                 A.RandomGamma(p=0.0),
-                A.ImageCompression(quality_lower=50, p=0.9),
+                A.ImageCompression(quality_lower=75, p=0.75),
             ]  # transforms
             self.transform = A.Compose(T, bbox_params=A.BboxParams(format="yolo", label_fields=["class_labels"]))
 


### PR DESCRIPTION
## What?
 
ImageCompression augmentation is now enabled
 
## Why?
 
We are now integrating our products with third-party cameras and connecting to their RTSP stream which has compression by h264 encoding, whereas before we had direct access to the camera RAW images.
 
## How?
 
Minimal changes to albumentation's existing pipeline.
 
## Testing
 
![image](https://github.com/user-attachments/assets/0642edc2-4483-419d-8cd0-4c88d1b239f4)

