### PR TITLE
Add ImageCompression Probability Parameter in `train.py`

### DIFF
--- a/train.py
+++ b/train.py
@@ -616,7 +616,7 @@ def parse_opt(known=False):
     parser.add_argument("--close-mosaic", type=int, default=0, help="Close mosaic N epochs before end. 0 to disable")
 
     # introduce compression artifacts (value from 0 to 1.0)
-    parser.add_argument("--image-compression", type=int, default=0.9, help="Image compression probability (data Augmentation). 0 to disable")
+    parser.add_argument("--image-compression", type=float, default=0.9, help="Image compression probability (data Augmentation). 0 to disable")
 
     # Logger arguments
     parser.add_argument("--entity", default=None, help="Entity")
@@ -974,7 +974,8 @@ def run(**kwargs):
         save_period (int, optional): Frequency in epochs to save checkpoints. Disabled if < 1. Defaults to -1.
         seed (int, optional): Global training random seed. Defaults to 0.
         local_rank (int, optional): Automatic DDP Multi-GPU argument. Do not modify. Defaults to -1.
-
+        image_compression (float, optional): Image compression probability (data Augmentation). Default is 0.9 and 0 to disable.
+        
     Returns:
         None: The function initiates YOLOv5 training or hyperparameter evolution based on the provided options.
 

--- a/train.py
+++ b/train.py
@@ -134,7 +134,7 @@ def train(hyp, opt, device, callbacks):
         - Datasets: https://github.com/ultralytics/yolov5/tree/master/data
         - Tutorial: https://docs.ultralytics.com/yolov5/tutorials/train_custom_data
     """
-    save_dir, epochs, batch_size, weights, single_cls, evolve, data, cfg, resume, noval, nosave, workers, freeze, image_compression = (
+    save_dir, epochs, batch_size, weights, single_cls, evolve, data, cfg, resume, noval, nosave, workers, freeze, im_compression_prob = (
         Path(opt.save_dir),
         opt.epochs,
         opt.batch_size,
@@ -148,7 +148,7 @@ def train(hyp, opt, device, callbacks):
         opt.nosave,
         opt.workers,
         opt.freeze,
-        opt.image_compression
+        opt.im_compression_prob
     )
     callbacks.run("on_pretrain_routine_start")
 
@@ -301,7 +301,7 @@ def train(hyp, opt, device, callbacks):
         prefix=colorstr("train: "),
         shuffle=True,
         seed=opt.seed,
-        image_compression = image_compression
+        im_compression_prob = im_compression_prob
     )
     labels = np.concatenate(dataset.labels, 0)
     mlc = int(labels[:, 0].max())  # max label class
@@ -322,7 +322,6 @@ def train(hyp, opt, device, callbacks):
             workers=workers * 2,
             pad=0.5,
             prefix=colorstr("val: "),
-            image_compression = image_compression,
         )[0]
 
         if not resume:
@@ -473,7 +472,6 @@ def train(hyp, opt, device, callbacks):
                     plots=False,
                     callbacks=callbacks,
                     compute_loss=compute_loss,
-                    image_compression = image_compression
                 )
 
             # Update best mAP
@@ -539,7 +537,6 @@ def train(hyp, opt, device, callbacks):
                         plots=plots,
                         callbacks=callbacks,
                         compute_loss=compute_loss,
-                        image_compression = image_compression,
                     )  # val best model with plots
                     if is_coco:
                         callbacks.run("on_fit_epoch_end", list(mloss) + list(results) + lr, epoch, best_fitness, fi)
@@ -616,7 +613,7 @@ def parse_opt(known=False):
     parser.add_argument("--close-mosaic", type=int, default=0, help="Close mosaic N epochs before end. 0 to disable")
 
     # introduce compression artifacts (value from 0 to 1.0)
-    parser.add_argument("--image-compression", type=float, default=0.9, help="Image compression probability (data Augmentation). 0 to disable")
+    parser.add_argument("--im-compression-prob", type=float, default=0.9, help="Image compression probability (data Augmentation). 0 to disable")
 
     # Logger arguments
     parser.add_argument("--entity", default=None, help="Entity")
@@ -974,7 +971,7 @@ def run(**kwargs):
         save_period (int, optional): Frequency in epochs to save checkpoints. Disabled if < 1. Defaults to -1.
         seed (int, optional): Global training random seed. Defaults to 0.
         local_rank (int, optional): Automatic DDP Multi-GPU argument. Do not modify. Defaults to -1.
-        image_compression (float, optional): Image compression probability (data Augmentation). Default is 0.9 and 0 to disable.
+        im_compression_prob (float, optional): Image compression probability (data Augmentation). Default is 0.9 and 0 to disable.
         
     Returns:
         None: The function initiates YOLOv5 training or hyperparameter evolution based on the provided options.

--- a/train.py
+++ b/train.py
@@ -134,7 +134,7 @@ def train(hyp, opt, device, callbacks):
         - Datasets: https://github.com/ultralytics/yolov5/tree/master/data
         - Tutorial: https://docs.ultralytics.com/yolov5/tutorials/train_custom_data
     """
-    save_dir, epochs, batch_size, weights, single_cls, evolve, data, cfg, resume, noval, nosave, workers, freeze = (
+    save_dir, epochs, batch_size, weights, single_cls, evolve, data, cfg, resume, noval, nosave, workers, freeze, image_compression = (
         Path(opt.save_dir),
         opt.epochs,
         opt.batch_size,
@@ -148,6 +148,7 @@ def train(hyp, opt, device, callbacks):
         opt.nosave,
         opt.workers,
         opt.freeze,
+        opt.image_compression
     )
     callbacks.run("on_pretrain_routine_start")
 
@@ -300,6 +301,7 @@ def train(hyp, opt, device, callbacks):
         prefix=colorstr("train: "),
         shuffle=True,
         seed=opt.seed,
+        image_compression = image_compression
     )
     labels = np.concatenate(dataset.labels, 0)
     mlc = int(labels[:, 0].max())  # max label class
@@ -320,6 +322,7 @@ def train(hyp, opt, device, callbacks):
             workers=workers * 2,
             pad=0.5,
             prefix=colorstr("val: "),
+            image_compression = image_compression,
         )[0]
 
         if not resume:
@@ -470,6 +473,7 @@ def train(hyp, opt, device, callbacks):
                     plots=False,
                     callbacks=callbacks,
                     compute_loss=compute_loss,
+                    image_compression = image_compression
                 )
 
             # Update best mAP
@@ -535,6 +539,7 @@ def train(hyp, opt, device, callbacks):
                         plots=plots,
                         callbacks=callbacks,
                         compute_loss=compute_loss,
+                        image_compression = image_compression,
                     )  # val best model with plots
                     if is_coco:
                         callbacks.run("on_fit_epoch_end", list(mloss) + list(results) + lr, epoch, best_fitness, fi)
@@ -609,6 +614,9 @@ def parse_opt(known=False):
 
     # close mosaic (a value between 10 and 15 seems to work fine)
     parser.add_argument("--close-mosaic", type=int, default=0, help="Close mosaic N epochs before end. 0 to disable")
+
+    # introduce compression artifacts (value from 0 to 1.0)
+    parser.add_argument("--image-compression", type=int, default=0.9, help="Image compression probability (data Augmentation). 0 to disable")
 
     # Logger arguments
     parser.add_argument("--entity", default=None, help="Entity")

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -22,8 +22,8 @@ FILL_VALUE = 0  # 114
 class Albumentations:
     """Provides optional data augmentation for YOLOv5 using Albumentations library if installed."""
 
-    def __init__(self, size=640):
-        """Initializes Albumentations class for optional data augmentation in YOLOv5 with specified input size."""
+    def __init__(self, size=640, image_compression=0.9):
+        """Initializes Albumentations class for optional data augmentation in YOLOv5 with specified input size and image compression probability."""
         self.transform = None
         prefix = colorstr("albumentations: ")
         try:
@@ -39,7 +39,7 @@ class Albumentations:
                 A.CLAHE(p=0.01),
                 A.RandomBrightnessContrast(p=0.0),
                 A.RandomGamma(p=0.0),
-                A.ImageCompression(quality_lower=50, p=0.90),
+                A.ImageCompression(quality_lower=50, p=image_compression),
             ]  # transforms
             self.transform = A.Compose(T, bbox_params=A.BboxParams(format="yolo", label_fields=["class_labels"]))
 

--- a/utils/augmentations.py
+++ b/utils/augmentations.py
@@ -22,7 +22,7 @@ FILL_VALUE = 0  # 114
 class Albumentations:
     """Provides optional data augmentation for YOLOv5 using Albumentations library if installed."""
 
-    def __init__(self, size=640, image_compression=0.9):
+    def __init__(self, size=640, im_compression_prob=0.9):
         """Initializes Albumentations class for optional data augmentation in YOLOv5 with specified input size and image compression probability."""
         self.transform = None
         prefix = colorstr("albumentations: ")
@@ -39,7 +39,7 @@ class Albumentations:
                 A.CLAHE(p=0.01),
                 A.RandomBrightnessContrast(p=0.0),
                 A.RandomGamma(p=0.0),
-                A.ImageCompression(quality_lower=50, p=image_compression),
+                A.ImageCompression(quality_lower=50, p=im_compression_prob),
             ]  # transforms
             self.transform = A.Compose(T, bbox_params=A.BboxParams(format="yolo", label_fields=["class_labels"]))
 

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -177,6 +177,7 @@ def create_dataloader(
     prefix="",
     shuffle=False,
     seed=0,
+    image_compression_p=0.9,
 ):
     """Creates and returns a configured DataLoader instance for loading and processing image datasets."""
     if rect and shuffle:
@@ -197,6 +198,7 @@ def create_dataloader(
             image_weights=image_weights,
             prefix=prefix,
             rank=rank,
+            image_compression_p = image_compression_p,
         )
 
     batch_size = min(batch_size, len(dataset))
@@ -561,6 +563,7 @@ class LoadImagesAndLabels(Dataset):
         prefix="",
         rank=-1,
         seed=0,
+        image_compression=0.9,
     ):
         """Initializes the YOLOv5 dataset loader, handling images and their labels, caching, and preprocessing."""
         self.img_size = img_size
@@ -572,7 +575,7 @@ class LoadImagesAndLabels(Dataset):
         self.mosaic_border = [-img_size // 2, -img_size // 2]
         self.stride = stride
         self.path = path
-        self.albumentations = Albumentations(size=img_size) if augment else None
+        self.albumentations = Albumentations(size=img_size, p=image_compression) if augment else None
 
         try:
             f = []  # image files

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -177,7 +177,7 @@ def create_dataloader(
     prefix="",
     shuffle=False,
     seed=0,
-    image_compression=0.9,
+    im_compression_prob=0.9,
 ):
     """Creates and returns a configured DataLoader instance for loading and processing image datasets."""
     if rect and shuffle:
@@ -198,7 +198,7 @@ def create_dataloader(
             image_weights=image_weights,
             prefix=prefix,
             rank=rank,
-            image_compression=image_compression,
+            im_compression_prob=im_compression_prob,
         )
 
     batch_size = min(batch_size, len(dataset))
@@ -563,7 +563,7 @@ class LoadImagesAndLabels(Dataset):
         prefix="",
         rank=-1,
         seed=0,
-        image_compression=0.9,
+        im_compression_prob=0.9,
     ):
         """Initializes the YOLOv5 dataset loader, handling images and their labels, caching, and preprocessing."""
         self.img_size = img_size
@@ -575,7 +575,7 @@ class LoadImagesAndLabels(Dataset):
         self.mosaic_border = [-img_size // 2, -img_size // 2]
         self.stride = stride
         self.path = path
-        self.albumentations = Albumentations(size=img_size, image_compression=image_compression) if augment else None
+        self.albumentations = Albumentations(size=img_size, im_compression_prob=im_compression_prob) if augment else None
 
         try:
             f = []  # image files

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -177,7 +177,7 @@ def create_dataloader(
     prefix="",
     shuffle=False,
     seed=0,
-    image_compression_p=0.9,
+    image_compression=0.9,
 ):
     """Creates and returns a configured DataLoader instance for loading and processing image datasets."""
     if rect and shuffle:
@@ -198,7 +198,7 @@ def create_dataloader(
             image_weights=image_weights,
             prefix=prefix,
             rank=rank,
-            image_compression_p = image_compression_p,
+            image_compression=image_compression,
         )
 
     batch_size = min(batch_size, len(dataset))

--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -575,7 +575,7 @@ class LoadImagesAndLabels(Dataset):
         self.mosaic_border = [-img_size // 2, -img_size // 2]
         self.stride = stride
         self.path = path
-        self.albumentations = Albumentations(size=img_size, p=image_compression) if augment else None
+        self.albumentations = Albumentations(size=img_size, image_compression=image_compression) if augment else None
 
         try:
             f = []  # image files

--- a/val.py
+++ b/val.py
@@ -253,6 +253,7 @@ def run(
         plots (bool, optional): Plot validation images and metrics. Default is True.
         callbacks (utils.callbacks.Callbacks, optional): Callbacks for logging and monitoring. Default is Callbacks().
         compute_loss (function, optional): Loss function for training. Default is None.
+        image_compression (float, optional): Image compression probability (data Augmentation). Default is 0.9 and 0 to disable.
 
     Returns:
         dict: Contains performance metrics including precision, recall, mAP50, and mAP50-95.
@@ -565,7 +566,7 @@ def parse_opt():
     parser.add_argument("--half", action="store_true", help="use FP16 half-precision inference")
     parser.add_argument("--dnn", action="store_true", help="use OpenCV DNN for ONNX inference")
     parser.add_argument("--hyp", type=str, default="", help="hyperparameters path")
-    parser.add_argument("--image-compression", type=int, default=0.9, help="Image compression probability (data Augmentation). 0 to disable")
+    parser.add_argument("--image-compression", type=float, default=0.9, help="Image compression probability (data Augmentation). 0 to disable")
 
     opt = parser.parse_args()
     opt.data = check_yaml(opt.data)  # check YAML

--- a/val.py
+++ b/val.py
@@ -217,6 +217,7 @@ def run(
     callbacks=Callbacks(),
     compute_loss=None,
     hyp=None,
+    image_compression=0.9
 ):
     """
     Evaluates a YOLOv5 model on a dataset and logs performance metrics.
@@ -325,6 +326,7 @@ def run(
             rect=rect,
             workers=workers,
             prefix=colorstr(f"{task}: "),
+            image_compression=image_compression,
         )[0]
 
     seen = 0
@@ -563,6 +565,8 @@ def parse_opt():
     parser.add_argument("--half", action="store_true", help="use FP16 half-precision inference")
     parser.add_argument("--dnn", action="store_true", help="use OpenCV DNN for ONNX inference")
     parser.add_argument("--hyp", type=str, default="", help="hyperparameters path")
+    parser.add_argument("--image-compression", type=int, default=0.9, help="Image compression probability (data Augmentation). 0 to disable")
+
     opt = parser.parse_args()
     opt.data = check_yaml(opt.data)  # check YAML
     opt.hyp = check_yaml(opt.hyp) if opt.hyp else opt.hyp  # check YAML

--- a/val.py
+++ b/val.py
@@ -217,7 +217,6 @@ def run(
     callbacks=Callbacks(),
     compute_loss=None,
     hyp=None,
-    image_compression=0.9
 ):
     """
     Evaluates a YOLOv5 model on a dataset and logs performance metrics.
@@ -253,7 +252,6 @@ def run(
         plots (bool, optional): Plot validation images and metrics. Default is True.
         callbacks (utils.callbacks.Callbacks, optional): Callbacks for logging and monitoring. Default is Callbacks().
         compute_loss (function, optional): Loss function for training. Default is None.
-        image_compression (float, optional): Image compression probability (data Augmentation). Default is 0.9 and 0 to disable.
 
     Returns:
         dict: Contains performance metrics including precision, recall, mAP50, and mAP50-95.
@@ -326,8 +324,7 @@ def run(
             pad=pad,
             rect=rect,
             workers=workers,
-            prefix=colorstr(f"{task}: "),
-            image_compression=image_compression,
+            prefix=colorstr(f"{task}: ")
         )[0]
 
     seen = 0


### PR DESCRIPTION
## What?

A new input parameter added to the train.py

## Why?

it was impossible to pass and control the compression parameters in the training script


## How?

The implementation adds an additional input parameter called im_compression_prob that controls the probability of applying the image compression. Specifically:

    If im_compression_prob = 1.0, the compression is applied 100% of the time.
    If im_compression_prob = 0.5, the compression is applied 50% of the time 
    If im_compression_prob = 0.0, the compression is applied 0% of the time (never applied).

If not specified, the default is 0.9.

## Testing

The compression parameter can be used within the run function in ```train.py``` like this: 

```python
import train
train.run(data='coco128.yaml', imgsz=320, weights='yolov5m.pt',im_compression_prob=0.7)
```
![image](https://github.com/user-attachments/assets/0c464bfc-6d25-4b58-9076-d15d9d343a33)

After a few lines, you can see that the ImageCompression function is used with the chosen image compression probability value: 
```albumentations: ... ImageCompression(p=0.7, quality_range=(50, 100), compression_type='jpeg')```
![image](https://github.com/user-attachments/assets/6b5e0cce-ffc9-4c4f-80c3-72138aaf2e83)

**Note**: Albumentations needs to be installed in order to run the ImageCompression function. Otherwise, the input values won't affect anything during training.


