### PR TITLE
Cv 220 make yolov5 m ap agnostic

### DIFF
--- a/train.py
+++ b/train.py
@@ -140,7 +140,7 @@ def train(hyp, opt, device, callbacks):
         opt.batch_size,
         opt.weights,
         opt.single_cls,
-        opt.single_cls_val
+        opt.single_cls_val,
         opt.evolve,
         opt.data,
         opt.cfg,
@@ -684,6 +684,7 @@ def main(opt, callbacks=Callbacks()):
 
     # DDP mode
     device = select_device(opt.device, batch_size=opt.batch_size)
+    
     if opt.single_cls_val:
         opt.image_weights = False
         LOGGER.warning(

--- a/train.py
+++ b/train.py
@@ -134,12 +134,13 @@ def train(hyp, opt, device, callbacks):
         - Datasets: https://github.com/ultralytics/yolov5/tree/master/data
         - Tutorial: https://docs.ultralytics.com/yolov5/tutorials/train_custom_data
     """
-    save_dir, epochs, batch_size, weights, single_cls, evolve, data, cfg, resume, noval, nosave, workers, freeze, im_compression_prob = (
+    save_dir, epochs, batch_size, weights, single_cls, single_cls_val, evolve, data, cfg, resume, noval, nosave, workers, freeze, im_compression_prob = (
         Path(opt.save_dir),
         opt.epochs,
         opt.batch_size,
         opt.weights,
         opt.single_cls,
+        opt.single_cls_val
         opt.evolve,
         opt.data,
         opt.cfg,
@@ -314,7 +315,7 @@ def train(hyp, opt, device, callbacks):
             imgsz,
             batch_size // WORLD_SIZE * 2,
             gs,
-            single_cls,
+            single_cls_val,
             hyp=hyp,
             cache=None if noval else opt.cache,
             rect=True,
@@ -466,7 +467,7 @@ def train(hyp, opt, device, callbacks):
                     imgsz=imgsz,
                     half=amp,
                     model=ema.ema,
-                    single_cls=single_cls,
+                    single_cls=single_cls_val,
                     dataloader=val_loader,
                     save_dir=save_dir,
                     plots=False,
@@ -529,7 +530,7 @@ def train(hyp, opt, device, callbacks):
                         imgsz=imgsz,
                         model=attempt_load(f, device).half(),
                         iou_thres=0.65 if is_coco else 0.60,  # best pycocotools at iou 0.65
-                        single_cls=single_cls,
+                        single_cls=single_cls_val,
                         dataloader=val_loader,
                         save_dir=save_dir,
                         save_json=is_coco,
@@ -594,6 +595,7 @@ def parse_opt(known=False):
     parser.add_argument("--device", default="", help="cuda device, i.e. 0 or 0,1,2,3 or cpu")
     parser.add_argument("--multi-scale", action="store_true", help="vary img-size +/- 50%%")
     parser.add_argument("--single-cls", action="store_true", help="train multi-class data as single-class")
+    parser.add_argument("--single-cls-val", action="store_true", help="validate multi-class data as single-class")
     parser.add_argument("--optimizer", type=str, choices=["SGD", "Adam", "AdamW"], default="SGD", help="optimizer")
     parser.add_argument("--sync-bn", action="store_true", help="use SyncBatchNorm, only available in DDP mode")
     parser.add_argument("--workers", type=int, default=8, help="max dataloader workers (per RANK in DDP mode)")
@@ -682,6 +684,12 @@ def main(opt, callbacks=Callbacks()):
 
     # DDP mode
     device = select_device(opt.device, batch_size=opt.batch_size)
+    if opt.single_cls_val:
+        opt.image_weights = False
+        LOGGER.warning(
+            "WARNING single_cls_val=True is not compatible with image-weights=True, disabling image-weights"
+        )
+
     if LOCAL_RANK != -1:
         msg = "is not compatible with YOLOv5 Multi-GPU DDP training"
         assert not opt.image_weights, f"--image-weights {msg}"

--- a/train.py
+++ b/train.py
@@ -688,7 +688,7 @@ def main(opt, callbacks=Callbacks()):
     if opt.single_cls_val and opt.image_weights:
         raise NotImplementedError(
                                   "--image-weights and --single-cls-val are incompatible with each other."
-                                  "image weighting need to results from multi-class validatino to weight the images"
+                                  "image weighting need to results from multi-class validation to weight the images"
                                   )
 
     if LOCAL_RANK != -1:

--- a/train.py
+++ b/train.py
@@ -685,11 +685,11 @@ def main(opt, callbacks=Callbacks()):
     # DDP mode
     device = select_device(opt.device, batch_size=opt.batch_size)
     
-    if opt.single_cls_val:
-        opt.image_weights = False
-        LOGGER.warning(
-            "WARNING single_cls_val=True is not compatible with image-weights=True, disabling image-weights"
-        )
+    if opt.single_cls_val and opt.image_weights:
+        raise NotImplementedError(
+                                  "--image-weights and --single-cls-val are incompatible with each other."
+                                  "image weighting need to results from multi-class validation to weight the images"
+                                  )
 
     if LOCAL_RANK != -1:
         msg = "is not compatible with YOLOv5 Multi-GPU DDP training"
@@ -966,6 +966,7 @@ def run(**kwargs):
         device (str, optional): CUDA device identifier, e.g., '0', '0,1,2,3', or 'cpu'. Defaults to an empty string.
         multi_scale (bool, optional): Use multi-scale training, varying image size by ±50%. Defaults to False.
         single_cls (bool, optional): Train with multi-class data as single-class. Defaults to False.
+        single-cls-val (bool, optional): Validate with multi-class data as single-class. Defaults to False. Not compatible with image_weights.
         optimizer (str, optional): Optimizer type, choices are ['SGD', 'Adam', 'AdamW']. Defaults to 'SGD'.
         sync_bn (bool, optional): Use synchronized BatchNorm, only available in DDP mode. Defaults to False.
         workers (int, optional): Maximum dataloader workers per rank in DDP mode. Defaults to 8.

--- a/train.py
+++ b/train.py
@@ -688,7 +688,7 @@ def main(opt, callbacks=Callbacks()):
     if opt.single_cls_val and opt.image_weights:
         raise NotImplementedError(
                                   "--image-weights and --single-cls-val are incompatible with each other."
-                                  "image weighting need to results from multi-class validation to weight the images"
+                                  "image weighting need to results from multi-class validatino to weight the images"
                                   )
 
     if LOCAL_RANK != -1:

--- a/val.py
+++ b/val.py
@@ -330,6 +330,8 @@ def run(
     seen = 0
     confusion_matrix = ConfusionMatrix(nc=nc)
     names = model.names if hasattr(model, "names") else model.module.names  # get class names
+    if single_cls:
+        names = {0: "item"}
     if isinstance(names, (list, tuple)):  # old format
         names = dict(enumerate(names))
     class_map = coco80_to_coco91_class() if is_coco else list(range(1000))

--- a/val.py
+++ b/val.py
@@ -359,7 +359,8 @@ def run(
         # Loss
         if compute_loss:
             loss += compute_loss(train_out, targets)[1]  # box, obj, cls
-
+            if single_cls:
+                loss[2] = 0 #cls loss override to zero
         # NMS
         targets[:, 2:] *= torch.tensor((width, height, width, height), device=device)  # to pixels
         lb = [targets[targets[:, 0] == i, 1:] for i in range(nb)] if save_hybrid else []  # for autolabelling


### PR DESCRIPTION
## What?
 
We want to have the **possibility** to, during training, do the validation step as single class, even when training as multi-cass.
 
## Why?

- our main requirement for cnn training is identification, rather then classification.
- with this approach we can cut out the need to upload our cnns to fiftyone to get a first feeling on identification performance
 
## How?
 
we add the following flag:
```python
    parser.add_argument("--single-cls-val", action="store_true", help="validate multi-class data as single-class")
```
we then feed ```single_cls = single_cls_val``` to all calls on ```validate.run``` and also in ```val_loader = create_dataloader```

## Backout plan

substitute ```single_cls_val``` appearances by ```single_cls```

## Information

If image-weights and single-cls-val are both true, the following error is raised

```
61 Traceback (most recent call last):
62   File "/launch/launch_training.py", line 139, in <module>
63     main()
64   File "/launch/launch_training.py", line 134, in main
65     train.run(**train_args)
66   File "/launch/yolov5/train.py", line 1003, in run
67     main(opt)
68   File "/launch/yolov5/train.py", line 689, in main
69     raise NotImplementedError(
70 NotImplementedError: --image-weights and --single-cls-val are incompatible with each other.image weighting need to results from multi-class validatino to weight the images
```
