### PR TITLE
Load-image-in-BGR-format

### DIFF
--- a/utils/dataloaders.py
+++ b/utils/dataloaders.py
@@ -1062,14 +1062,22 @@ class LoadImagesAndLabels(Dataset):
 
 
 # Ancillary functions --------------------------------------------------------------------------------------------------
-def imread_16bit_compatible(f, augment16=False):
+def imread_16bit_compatible(f: str, augment16: bool = False) -> np.ndarray:
+    """
+    Loads an image and returns it in BGR format, it
+    converts 16-bit images to 8-bit with optional augmentation.
+
+    Args:
+        f (str): Image file path.
+        augment16 (bool): Apply augmentation during conversion from 16-bit to 8bit.
+
+    Returns:
+        np.ndarray: Image in BGR format.
+    """
     # Read image with OpenCV, convert from 16-bit to 8-bit if necessary
-    im = cv2.imread(f, cv2.IMREAD_UNCHANGED)
-    if im.dtype == np.uint8:
-        if im.ndim == 2 or im.shape[2] == 1:
-            im = cv2.cvtColor(im, cv2.COLOR_GRAY2RGB)  # RGB
-        else:
-            im = cv2.cvtColor(im, cv2.COLOR_BGR2RGB)  # RGB
+    im = cv2.imread(f, cv2.IMREAD_UNCHANGED)  # load image as BGR if 3-ch image
+    if im.dtype == np.uint8 and (im.ndim == 2 or im.shape[-1] == 1):
+        im = cv2.cvtColor(im, cv2.COLOR_GRAY2BGR) # BGR    
     if im.dtype == np.uint16:
         try:
             from utils.albumentations16 import convert_16bit_to_8bit


### PR DESCRIPTION
## What?
 
Ensure that the loader function returns always images in the BGR format.
 
## Why?
 
The 3-channels images were loaded as BGR and converted to RGB which was not the expected output.
 
## How?
 
Get ride of the extra converstion in the `imread_16bit_compatible()` function located in the dataloader:

```diff
...
im = cv2.imread(f, cv2.IMREAD_UNCHANGED)  # load image as BGR if 3-ch image
if im.dtype == np.uint8:
    if im.ndim == 2 or im.shape[2] == 1:
        im = cv2.cvtColor(im, cv2.COLOR_GRAY2BGR)  # BGR
-   else:
-        im = cv2.cvtColor(im, cv2.COLOR_BGR2RGB)  # RGB
...
```


## Backout plan

Not needed but easy to change.

## Testing
 
![image](https://github.com/user-attachments/assets/a3815a82-0c05-4dfa-a1de-99bb9f6c097b)

| Before the fix | After the fix |
|---------|---------|
| ![image](https://github.com/user-attachments/assets/f9894a5c-6233-4e51-afa8-ad4bcc0dcfad) | ![image](https://github.com/user-attachments/assets/59085614-8653-4f63-b54b-34e8c4b0e67a) |





