### PR TITLE
Export AHOY using models from W&B registry

### DIFF
--- a/export.py
+++ b/export.py
@@ -647,7 +647,7 @@ def export_onnx_trt7_compatible(model, im, file, dynamic, simplify, opset=12, pr
         model = Model(cfg)  # Create YOLOv5 model
         im = torch.zeros((1, 3, 640, 640))  # Example input
         file = Path('model_trt7.onnx')
-        export_trt_7_compatible_onnx(model, im, file, dynamic=True, simplify=True)
+        export_onnx_trt7_compatible(model, im, file, dynamic=True, simplify=True)
         ```
     """
     LOGGER.info(f"\n{prefix} exporting TensorRT 7 compatible ONNX...")
@@ -690,8 +690,6 @@ def export_engine(
         verbose (bool): Set to True for verbose logging output.
         cache (str): Path to save the TensorRT timing cache.
         prefix (str): Log message prefix.
-        onnx_only (bool): Set to True to only export the ONNX model.
-        trt_7_compatible (bool): Set to True to export a TensorRT 7 compatible model.
 
     Returns:
         (pathlib.Path, None): Tuple containing the path to the exported model and None.


### PR DESCRIPTION
## What?
 
1. Fetch the pytorch models from our W&B registry ®️  and export/build an ONNX ahoy with them.
2. Regardless of exporting as float (fp32) or half (fp16), it will have softmax as part of the ONNX graph.
 
## Why?
 
1. Less manual steps needed, step towards automation ⚙️ 
2. Softmax in GPU is fastah 🏎️ 
 
## How?
 
1. Use wandb sdk to downloads the artifacts and return the path to the `.pt` file.

```bash
python3 export_ahoy.py -dw <COLLECTION>:<version> -hw <COLLECTION>:<version> -sz 1280 -bs 2 --fuse
# eg:
python3 export_ahoy.py -dw YOLOv5n6-RGB:latest -hw YOLOv5h6-RGB:latest -sz 1280 -bs 2 --fuse
```

3. Re-worked some old logic.

## Backout plan

1. Keep downloading manually 🤮 
2. Do softmax on the CPU 🤮 🤮 
 
## Testing

## W&B exporting

```bash
python3 export_ahoy.py -dw YOLOv5n6-RGB:latest -hw YOLOv5h6-RGB:latest -sz 1280 -bs 2 --fuse -f ~/Downloads/ahoy-RGB-float.onnx
wandb:   1 of 1 files downloaded.  
wandb:   1 of 1 files downloaded.  
YOLOv5 🚀 v7.0-450-g3fe66d1d Python-3.12.2 torch-2.5.1 CPU

Fusing layers... 
Model summary: 206 layers, 3104644 parameters, 0 gradients, 4.3 GFLOPs
Loaded weights from /Users/kevinserrano/GitHub/SEA-AI/yolov5/artifacts/run_0r9jjovs_model:v0/best.pt
YOLOv5 🚀 v7.0-450-g3fe66d1d Python-3.12.2 torch-2.5.1 CPU

Fusing layers... 
Model summary: 144 layers, 3353720 parameters, 0 gradients, 3.0 GFLOPs
Loaded weights from /Users/kevinserrano/GitHub/SEA-AI/yolov5/artifacts/yolov5h-mpnfvpd9:v0/best.pt
YOLOv5 🚀 v7.0-450-g3fe66d1d Python-3.12.2 torch-2.5.1 CPU

🚀 Exporting model AHOY to /Users/kevinserrano/Downloads/ahoy-RGB-float.onnx...
✨ Preparing the model for export...
🔮 Dummy input...torch.Size([2, 3, 1280, 1280]), torch.uint8

ONNX: starting export with onnx 1.17.0...

# warning about treating booleans as constants...

ONNX: export success ✅ 1.5s, saved as /Users/kevinserrano/Downloads/ahoy-RGB-float.onnx (26.3 MB)
🎉 Model successfully exported to /Users/kevinserrano/Downloads/ahoy-RGB-float.onnx! 🚀
```

```bash
python3 export_ahoy.py -dw YOLOv5n6-RGB:latest -hw YOLOv5h6-RGB:latest -sz 1280 -bs 2 --fuse --half -f ~/Downloads/ahoy-RGB-half.onnx
wandb:   1 of 1 files downloaded.  
wandb:   1 of 1 files downloaded.  
YOLOv5 🚀 v7.0-450-g3fe66d1d Python-3.12.2 torch-2.5.1 CPU

Fusing layers... 
Model summary: 206 layers, 3104644 parameters, 0 gradients, 4.3 GFLOPs
Loaded weights from /Users/kevinserrano/GitHub/SEA-AI/yolov5/artifacts/run_0r9jjovs_model:v0/best.pt
YOLOv5 🚀 v7.0-450-g3fe66d1d Python-3.12.2 torch-2.5.1 CPU

Fusing layers... 
Model summary: 144 layers, 3353720 parameters, 0 gradients, 3.0 GFLOPs
Loaded weights from /Users/kevinserrano/GitHub/SEA-AI/yolov5/artifacts/yolov5h-mpnfvpd9:v0/best.pt
YOLOv5 🚀 v7.0-450-g3fe66d1d Python-3.12.2 torch-2.5.1 CPU

🚀 Exporting model AHOY to /Users/kevinserrano/Downloads/ahoy-RGB-half.onnx...
✨ Preparing the model for export...
🔮 Dummy input...torch.Size([2, 3, 1280, 1280]), torch.uint8

ONNX: starting export with onnx 1.17.0...

# warning about treating booleans as constants...

ONNX: export success ✅ 10.1s, saved as /Users/kevinserrano/Downloads/ahoy-RGB-half.onnx (13.2 MB)
🎉 Model successfully exported to /Users/kevinserrano/Downloads/ahoy-RGB-half.onnx! 🚀
```

## Float vs Half

Here's float (left) vs half (right) ONNX graphs visualised using netron.app. As you can see, both outputs are float32 and cast to float32 is only done in the _halfed_ model.

![image](https://github.com/user-attachments/assets/60f43076-286c-450a-92c7-dcd51ca51486)

### Float version

```python
import matplotlib.pyplot as plt

model = AHOY("/Users/kevinserrano/Downloads/ahoy-RGB-float.onnx")
outputs = model.forward(model.preprocess([im, roi]))

fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(8, 6))
ax1.bar(x=np.arange(len(outputs["output1"][1])), height=outputs["output1"][1])
ax1.set_title("Output 1")
ax2.bar(x=np.arange(len(outputs["output2"][1])), height=outputs["output2"][1])
ax2.set_title("Output 2")
plt.tight_layout()
plt.show()
```

![image](https://github.com/user-attachments/assets/955278d2-03f7-489e-af2c-b57e48c5b6e3)


### Half version

```python
import matplotlib.pyplot as plt

model = AHOY("/Users/kevinserrano/Downloads/ahoy-RGB-half.onnx")
outputs = model.forward(model.preprocess([im, roi]))

fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(8, 6))
ax1.bar(x=np.arange(len(outputs["output1"][1])), height=outputs["output1"][1])
ax1.set_title("Output 1")
ax2.bar(x=np.arange(len(outputs["output2"][1])), height=outputs["output2"][1])
ax2.set_title("Output 2")
plt.tight_layout()
plt.show()
```

![image](https://github.com/user-attachments/assets/a001d01a-5d32-4ba4-8ae5-d56403e34d65)
