### PR TITLE
CV-310: Horizon training with non-square input size

### DIFF
--- a/horizon/dataloaders.py
+++ b/horizon/dataloaders.py
@@ -16,9 +16,10 @@ from torch.utils.data import DataLoader, Dataset
 
 import horizon.transforms as T
 
+
 def get_train_dataloader(
     dataset: fo.Dataset,
-    imgsz: int,
+    imgsz: Tuple[int, int],
     batch_size: int = 16,
     num_workers: int = 8,
     shuffle: bool = True,
@@ -44,7 +45,7 @@ def get_train_dataloader(
     
 def get_val_dataloader(
     dataset: fo.Dataset,
-    imgsz: int,
+    imgsz: Tuple[int, int],
     batch_size: int = 16,
     num_workers: int = 8,
     shuffle: bool = False,

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -233,6 +233,13 @@ def evaluate(
 
     return v_loss, v_ploss, v_tloss, mse_pitch, mse_theta
 
+def _log_device_info():
+    print("CUDA Available:", torch.cuda.is_available())
+    print("GPU Count:", torch.cuda.device_count())
+
+    for i in range(torch.cuda.device_count()):
+        print(f"GPU {i}: {torch.cuda.get_device_name(i)}")
+
 def _setup_device(device_spec):
     """Configure CUDA device settings and return normalized device string."""
     if device_spec == "cuda":
@@ -290,6 +297,8 @@ def run(
 
     # configure device
     device = _setup_device(device)
+
+    _log_device_info()
 
     # ensure that imgsz is a tuple (height, width)
     imgsz = tuple([imgsz] * 2) if isinstance(imgsz, int) else imgsz

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -496,7 +496,7 @@ def get_wb_images(model: HorizonModel, dataloader: DataLoader, n=10):
             orig_hw=im.shape[:2],  # H, W, C
         )
         y_points = np.array(y_points).astype(np.int32)
-        y_mask = np.zeros(im.shape, dtype=np.uint8)  # 0-->background, 1-->horizon
+        y_mask = np.zeros(im.shape[:2], dtype=np.uint8)  # 0-->background, 1-->horizon
         cv2.line(y_mask, y_points[0], y_points[1], color=1, thickness=4)
 
         wb_images.append(

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -233,7 +233,8 @@ def evaluate(
 
     return v_loss, v_ploss, v_tloss, mse_pitch, mse_theta
 
-def _log_device_info():
+def _log_device_info(device):
+    print("Device Info:", device)
     print("CUDA Available:", torch.cuda.is_available())
     print("GPU Count:", torch.cuda.device_count())
 
@@ -254,7 +255,7 @@ def _setup_device(device_spec):
         
        
     # Return either "cpu" or "cuda:X" format
-    return "cpu" if device == "cpu" else str(device)
+    return "cpu" if device == "cpu" else f"cuda:{device}"
 
 
 def run(
@@ -299,7 +300,7 @@ def run(
     # configure device
     device = _setup_device(device)
 
-    _log_device_info()
+    _log_device_info(device)
 
     # ensure that imgsz is a tuple (height, width)
     imgsz = tuple([imgsz] * 2) if isinstance(imgsz, int) else imgsz

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -15,6 +15,7 @@ import sys
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
+from typing import Tuple
 
 import cv2
 import fiftyone as fo
@@ -36,10 +37,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))  # add ROOT to PATH
 ROOT = Path(os.path.relpath(ROOT, Path.cwd()))  # relative
 
-from horizon.dataloaders import (  # noqa: E402
-    get_train_dataloader,
-    get_val_dataloader
-)
+from horizon.dataloaders import get_train_dataloader, get_val_dataloader  # noqa: E402
 from models.custom import HorizonModel  # noqa: E402
 from utils.autobatch import check_train_batch_size  # noqa: E402
 from utils.downloads import attempt_download  # noqa: E402
@@ -52,7 +50,7 @@ def get_dataloaders(
     dataset_name: str,
     train_tag: str,
     val_tag: str,
-    imgsz: int,
+    imgsz: Tuple[int, int],
     im_compression_prob: float,
     batch_size: int,
     field: str = "ground_truth_pl.polylines.closed",
@@ -245,7 +243,7 @@ def run(
     nc_theta: int = 500,  # number of theta classes
     pitch_weight: float = 1.0,  # pitch loss weight
     theta_weight: float = 1.0,  # theta loss weight
-    imgsz: int = 640,  # model input size (assumes squared input)
+    imgsz: Tuple[int, int]=(640, 640),  # model input size (height, width)
     epochs: int = 100,
     dropout: float = 0.25,  # dropout rate for classification heads
     im_compression_prob: float = 0.9,
@@ -264,7 +262,7 @@ def run(
         nc_theta (int): Number of theta classes.
         pitch_weight (float): Weight for pitch loss.
         theta_weight (float): Weight for theta loss.
-        imgsz (int): Model input size (assumes squared input).
+        imgsz Tuple[int, int]: Model input size (height, width).
         epochs (int): Number of training epochs.
         dropout (float): Dropout rate for classification heads.
         im_compression_prob (float): Probability for image compression augmentation.
@@ -520,7 +518,8 @@ def parse_args():
     parser.add_argument("--nc_theta", type=int, default=500, help="number of theta classes")
     parser.add_argument("--pitch_weight", type=float, default=1.0, help="pitch loss weight")
     parser.add_argument("--theta_weight", type=float, default=1.0, help="theta loss weight")
-    parser.add_argument("--imgsz", type=int, default=640, help="train, val image size")
+    parser.add_argument("--imgsz", type=int, nargs="*", default=(640, 640), help="train, val image size as height width (single value will be used for both height and width)"
+)
     parser.add_argument("--epochs", type=int, default=100, help="number of epochs")
     parser.add_argument("--dropout", type=float, default=0.25, help="dropout rate")
     parser.add_argument(
@@ -540,4 +539,8 @@ def parse_args():
 
 if __name__ == "__main__":
     args = parse_args()
+
+    # If only one value is provided, set both width and height to that value
+    args.imgsz = [args.imgsz] * 2 if isinstance(args.imgsz, int) else args.imgsz
+
     run(**vars(args))

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -234,30 +234,6 @@ def evaluate(
 
     return v_loss, v_ploss, v_tloss, mse_pitch, mse_theta
 
-def _log_device_info(device):
-    print("Device Info:", device)
-    print("CUDA Available:", torch.cuda.is_available())
-    print("GPU Count:", torch.cuda.device_count())
-
-    for i in range(torch.cuda.device_count()):
-        print(f"GPU {i}: {torch.cuda.get_device_name(i)}")
-
-    print(f"CUDA_VISIBLE_DEVICES={os.environ['CUDA_VISIBLE_DEVICES']}")
-
-
-def _setup_device(device_spec):
-    """Configure CUDA device settings and return normalized device string."""
-    if device_spec == "cuda":
-        device = str(torch.cuda.current_device())
-    elif isinstance(device_spec, int):
-        device = device_spec
-    else:
-        device = "cpu"
-        
-       
-    # Return either "cpu" or "cuda:X" format
-    return "cpu" if device == "cpu" else f"cuda:{device}"
-
 
 def run(
     dataset_name: str,  # fiftyone dataset name
@@ -297,11 +273,6 @@ def run(
     Returns:
         None
     """
-
-    # configure device
-    device = _setup_device(device)
-
-    _log_device_info(device)
 
     # ensure that imgsz is a tuple (height, width)
     imgsz = tuple([imgsz] * 2) if isinstance(imgsz, int) else imgsz

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -250,7 +250,8 @@ def _setup_device(device_spec):
         device = "cpu"
         
     # Set environment variable once at the end
-    os.environ["CUDA_VISIBLE_DEVICES"] = "" if device == "cpu" else device
+    os.environ["CUDA_DEVICE_ORDER"]="PCI_BUS_ID"
+    os.environ["CUDA_VISIBLE_DEVICES"] = "" if device == "cpu" else str(device)
     print(f"CUDA_VISIBLE_DEVICES={os.environ['CUDA_VISIBLE_DEVICES']}")
     
     # Return either "cpu" or "cuda:X" format

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -32,8 +32,6 @@ from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
-from utils.general import check_amp
-
 wandb.login()
 
 FILE = Path(__file__).resolve()
@@ -46,7 +44,7 @@ from horizon.dataloaders import get_train_dataloader, get_val_dataloader  # noqa
 from models.custom import HorizonModel  # noqa: E402
 from utils.autobatch import check_train_batch_size  # noqa: E402
 from utils.downloads import attempt_download  # noqa: E402
-from utils.general import LOGGER, TQDM_BAR_FORMAT  # noqa: E402
+from utils.general import LOGGER, TQDM_BAR_FORMAT, check_amp  # noqa: E402
 from utils.horizon import pitch_theta_to_points  # noqa: E402
 from utils.torch_utils import ModelEMA, smart_optimizer  # noqa: E402
 

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -481,12 +481,12 @@ def get_wb_images(model: HorizonModel, dataloader: DataLoader, n=10):
         y_pitch, y_theta = y_pitch.cpu().numpy(), y_theta.cpu().numpy()
 
         im = remove_black_padding(  # hack until dataloader is enhanced
-            (images[0, 0, ...] * 255).cpu().numpy().astype(np.uint8)
+            (images[0, ...] * 255).permute(1, 2, 0).cpu().numpy().astype(np.uint8)
         )
 
         gt_points = pitch_theta_to_points(targets[0], targets[1], input_hw=images.shape[-2:], orig_hw=im.shape[:2])
         gt_points = np.array(gt_points).astype(np.int32)
-        gt_mask = np.zeros(im.shape, dtype=np.uint8)  # 0=background, 1=horizon
+        gt_mask = np.zeros(im.shape, dtype=np.uint8)  # 0-->background, 1-->horizon
         cv2.line(gt_mask, gt_points[0], gt_points[1], color=1, thickness=4)
 
         y_points = pitch_theta_to_points(
@@ -496,7 +496,7 @@ def get_wb_images(model: HorizonModel, dataloader: DataLoader, n=10):
             orig_hw=im.shape[:2],
         )
         y_points = np.array(y_points).astype(np.int32)
-        y_mask = np.zeros(im.shape, dtype=np.uint8)  # 0=background, 1=horizon
+        y_mask = np.zeros(im.shape, dtype=np.uint8)  # 0-->background, 1-->horizon
         cv2.line(y_mask, y_points[0], y_points[1], color=1, thickness=4)
 
         wb_images.append(
@@ -517,7 +517,8 @@ def remove_black_padding(image):
     """Remove black padding from an image."""
 
     # Apply a binary threshold to detect non-black areas
-    _, binary = cv2.threshold(image, 1, 255, cv2.THRESH_BINARY)
+    gray = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY) if image.ndim == 3 else image
+    _, binary = cv2.threshold(gray, 1, 255, cv2.THRESH_BINARY)
 
     # Find contours
     contours, _ = cv2.findContours(binary, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -57,6 +57,7 @@ def get_dataloaders(
     im_compression_prob: float,
     batch_size: int,
     field: str = "ground_truth_pl.polylines.closed",
+    num_workers: int = 8,
 ):
     # TODO: add tag check
     train_dataloader = get_train_dataloader(
@@ -67,6 +68,7 @@ def get_dataloaders(
         imgsz=imgsz,
         batch_size=batch_size,
         im_compression_prob=im_compression_prob,
+        num_workers=num_workers,
     )
 
     val_dataloader = get_val_dataloader(
@@ -76,6 +78,7 @@ def get_dataloaders(
         ),
         imgsz=imgsz,
         batch_size=batch_size,
+        num_workers=num_workers,
     )
 
     return train_dataloader, val_dataloader

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -62,7 +62,7 @@ def get_dataloaders(
             # .take(5000, seed=51)
         ),
         imgsz=imgsz,
-        batch_size=batch_size if imgsz == 640 else 16,
+        batch_size=batch_size,
         im_compression_prob=im_compression_prob,
     )
 
@@ -72,7 +72,7 @@ def get_dataloaders(
             # .take(5000, seed=51)
         ),
         imgsz=imgsz,
-        batch_size=batch_size if imgsz == 640 else 16,
+        batch_size=batch_size,
     )
 
     return train_dataloader, val_dataloader

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -243,7 +243,7 @@ def run(
     nc_theta: int = 500,  # number of theta classes
     pitch_weight: float = 1.0,  # pitch loss weight
     theta_weight: float = 1.0,  # theta loss weight
-    imgsz: Tuple[int, int]=(640, 640),  # model input size (height, width)
+    imgsz: int | Tuple[int, int] = 640,  # model input size (height, width)
     epochs: int = 100,
     dropout: float = 0.25,  # dropout rate for classification heads
     im_compression_prob: float = 0.9,
@@ -262,7 +262,7 @@ def run(
         nc_theta (int): Number of theta classes.
         pitch_weight (float): Weight for pitch loss.
         theta_weight (float): Weight for theta loss.
-        imgsz Tuple[int, int]: Model input size (height, width).
+        imgsz int | Tuple[int, int]: Model input size (height, width) or single value for square input.
         epochs (int): Number of training epochs.
         dropout (float): Dropout rate for classification heads.
         im_compression_prob (float): Probability for image compression augmentation.
@@ -272,6 +272,10 @@ def run(
     Returns:
         None
     """
+
+    # ensure that imgsz is a tuple (height, width)
+    imgsz = tuple([imgsz] * 2) if isinstance(imgsz, int) else imgsz
+
     # create dir to store checkpoints
     ckpt_dir = ROOT / "runs" / "horizon" / "train" / dataset_name
     ckpt_dir.mkdir(parents=True, exist_ok=True)
@@ -518,8 +522,7 @@ def parse_args():
     parser.add_argument("--nc_theta", type=int, default=500, help="number of theta classes")
     parser.add_argument("--pitch_weight", type=float, default=1.0, help="pitch loss weight")
     parser.add_argument("--theta_weight", type=float, default=1.0, help="theta loss weight")
-    parser.add_argument("--imgsz", type=int, nargs="*", default=(640, 640), help="train, val image size as height width (single value will be used for both height and width)"
-)
+    parser.add_argument("--imgsz", type=int, nargs="*", default=640, help="train, val image size as height width (single value will be used for both height and width)")
     parser.add_argument("--epochs", type=int, default=100, help="number of epochs")
     parser.add_argument("--dropout", type=float, default=0.25, help="dropout rate")
     parser.add_argument(
@@ -539,8 +542,5 @@ def parse_args():
 
 if __name__ == "__main__":
     args = parse_args()
-
-    # If only one value is provided, set both width and height to that value
-    args.imgsz = [args.imgsz] * 2 if isinstance(args.imgsz, int) else args.imgsz
 
     run(**vars(args))

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -274,7 +274,7 @@ def run(
     """
 
     # ensure that imgsz is a tuple (height, width)
-    imgsz = tuple([imgsz] * 2) if isinstance(imgsz, int) else imgsz
+    imgsz = (imgsz, imgsz) if isinstance(imgsz, int) else imgsz
 
     # create dir to store checkpoints
     ckpt_dir = ROOT / "runs" / "horizon" / "train" / dataset_name

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -486,14 +486,14 @@ def get_wb_images(model: HorizonModel, dataloader: DataLoader, n=10):
 
         gt_points = pitch_theta_to_points(targets[0], targets[1], input_hw=images.shape[-2:], orig_hw=im.shape[:2])
         gt_points = np.array(gt_points).astype(np.int32)
-        gt_mask = np.zeros(im.shape, dtype=np.uint8)  # 0-->background, 1-->horizon
+        gt_mask = np.zeros(im.shape[:2], dtype=np.uint8)  # 0-->background, 1-->horizon
         cv2.line(gt_mask, gt_points[0], gt_points[1], color=1, thickness=4)
 
         y_points = pitch_theta_to_points(
             y_pitch.item(),
             y_theta.item(),
-            input_hw=images.shape[-2:],
-            orig_hw=im.shape[:2],
+            input_hw=images.shape[-2:],  # B, C, H, W
+            orig_hw=im.shape[:2],  # H, W, C
         )
         y_points = np.array(y_points).astype(np.int32)
         y_mask = np.zeros(im.shape, dtype=np.uint8)  # 0-->background, 1-->horizon

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -233,6 +233,21 @@ def evaluate(
 
     return v_loss, v_ploss, v_tloss, mse_pitch, mse_theta
 
+def _setup_device(device_spec):
+    """Configure CUDA device settings and return normalized device string."""
+    if device_spec == "cuda":
+        device = str(torch.cuda.current_device())
+    elif device_spec.isdigit():
+        device = device_spec
+    else:
+        device = "cpu"
+        
+    # Set environment variable once at the end
+    os.environ["CUDA_VISIBLE_DEVICES"] = "" if device == "cpu" else device
+    
+    # Return either "cpu" or "cuda:X" format
+    return "cpu" if device == "cpu" else f"cuda:{device}"
+
 
 def run(
     dataset_name: str,  # fiftyone dataset name
@@ -272,6 +287,9 @@ def run(
     Returns:
         None
     """
+
+    # configure device
+    device = _setup_device(device)
 
     # ensure that imgsz is a tuple (height, width)
     imgsz = tuple([imgsz] * 2) if isinstance(imgsz, int) else imgsz

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -240,6 +240,9 @@ def _log_device_info():
     for i in range(torch.cuda.device_count()):
         print(f"GPU {i}: {torch.cuda.get_device_name(i)}")
 
+    print(f"CUDA_VISIBLE_DEVICES={os.environ['CUDA_VISIBLE_DEVICES']}")
+
+
 def _setup_device(device_spec):
     """Configure CUDA device settings and return normalized device string."""
     if device_spec == "cuda":
@@ -249,13 +252,9 @@ def _setup_device(device_spec):
     else:
         device = "cpu"
         
-    # Set environment variable once at the end
-    os.environ["CUDA_DEVICE_ORDER"]="PCI_BUS_ID"
-    os.environ["CUDA_VISIBLE_DEVICES"] = "" if device == "cpu" else str(device)
-    print(f"CUDA_VISIBLE_DEVICES={os.environ['CUDA_VISIBLE_DEVICES']}")
-    
+       
     # Return either "cpu" or "cuda:X" format
-    return "cpu" if device == "cpu" else f"cuda:{device}"
+    return "cpu" if device == "cpu" else str(device)
 
 
 def run(

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -117,7 +117,6 @@ def update(
     for i, data in pbar:
         images, targets = data
         images, targets = images.to(model.device), targets.to(model.device)
-        print("using device", model.device)
 
         # process targets
         pitch_i, theta_i = model.to_discrete(pitch=targets[..., 0], theta=targets[..., 1])

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -244,13 +244,14 @@ def _setup_device(device_spec):
     """Configure CUDA device settings and return normalized device string."""
     if device_spec == "cuda":
         device = str(torch.cuda.current_device())
-    elif device_spec.isdigit():
+    elif isinstance(device_spec, int):
         device = device_spec
     else:
         device = "cpu"
         
     # Set environment variable once at the end
     os.environ["CUDA_VISIBLE_DEVICES"] = "" if device == "cpu" else device
+    print(f"CUDA_VISIBLE_DEVICES={os.environ['CUDA_VISIBLE_DEVICES']}")
     
     # Return either "cpu" or "cuda:X" format
     return "cpu" if device == "cpu" else f"cuda:{device}"

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -26,7 +26,6 @@ import torch
 import torch.nn as nn
 import wandb
 from fiftyone import ViewField as F
-from torch.cuda import amp
 from torch.nn import CrossEntropyLoss, Dropout
 from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.data import DataLoader
@@ -91,7 +90,7 @@ def update(
     loss_theta: CrossEntropyLoss,
     pitch_weight: float,
     theta_weight: float,
-    scaler: amp.GradScaler,
+    scaler: torch.cuda.amp.GradScaler,
     optimizer: torch.optim.Optimizer,
     ema: ModelEMA,
     epoch: int,
@@ -337,7 +336,8 @@ def run(
     loss_pitch = CrossEntropyLoss(label_smoothing=0.0)
     loss_theta = CrossEntropyLoss(label_smoothing=0.0)
 
-    scaler = amp.GradScaler(enabled=model.device != "cpu")
+    scaler = torch.cuda.amp.GradScaler(enabled=amp)
+
 
     ema = ModelEMA(model)
     best_mse = 1e10

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -32,6 +32,8 @@ from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
+from utils.general import check_amp
+
 wandb.login()
 
 FILE = Path(__file__).resolve()
@@ -317,7 +319,8 @@ def run(
 
     # Batch size
     if batch_size == -1:  # single-GPU only, estimate best batch size
-        batch_size = check_train_batch_size(model, imgsz)
+        amp = check_amp(model)  # check AMP
+        batch_size = check_train_batch_size(model, imgsz, amp)
     else:
         LOGGER.info(f"Batch Size = {batch_size}")
 

--- a/horizon/train.py
+++ b/horizon/train.py
@@ -117,6 +117,7 @@ def update(
     for i, data in pbar:
         images, targets = data
         images, targets = images.to(model.device), targets.to(model.device)
+        print("using device", model.device)
 
         # process targets
         pitch_i, theta_i = model.to_discrete(pitch=targets[..., 0], theta=targets[..., 1])

--- a/horizon/transforms.py
+++ b/horizon/transforms.py
@@ -36,7 +36,7 @@ def geometric_augment(imgsz: Tuple[int,int]) -> List[BasicTransform]:
     """
     return [
         A.RandomCropFromBorders(p=0.1),
-        Ax.ResizeIfNeeded(max_size=max(imgsz)),
+        Ax.ResizeIfNeeded(max_size=min(imgsz)),
         A.HorizontalFlip(p=0.5),
         A.PadIfNeeded(
             min_height=imgsz[0], min_width=imgsz[1], border_mode=cv2.BORDER_CONSTANT, value=0
@@ -108,7 +108,7 @@ def horizon_base_rgb(imgsz: Tuple[int,int]) -> A.Compose:
     return A.Compose(
         [
             # geometric transforms
-            Ax.ResizeIfNeeded(max_size=max(imgsz)),
+            Ax.ResizeIfNeeded(max_size=min(imgsz)),
             A.PadIfNeeded(
                 min_height=imgsz[0],
                 min_width=imgsz[1],
@@ -184,7 +184,7 @@ def horizon_base_ir16bit(
             A.UnsharpMask(p=1.0 if unsharp_mask else 0.0, threshold=5),
             A.ToRGB(p=1.0),
             # geometric transforms
-            Ax.ResizeIfNeeded(max_size=max(imgsz)),
+            Ax.ResizeIfNeeded(max_size=min(imgsz)),
             A.PadIfNeeded(
                 min_height=imgsz[0],
                 min_width=imgsz[1],

--- a/horizon/transforms.py
+++ b/horizon/transforms.py
@@ -9,17 +9,18 @@ Useful links:
 - https://albumentations.ai/docs/getting_started/transforms_and_targets/
 """
 
-from typing import List
-import numpy as np
-import cv2
+from typing import List, Tuple
+
 import albumentations as A
+import cv2
+import numpy as np
 from albumentations.core.transforms_interface import BasicTransform
 from albumentations.pytorch.transforms import ToTensorV2
 
 import utils.albumentations16 as A16
 import utils.albumextensions as Ax
-from utils.horizon import points_to_pitch_theta  # points_to_hough
 from utils.general import LOGGER, colorstr
+from utils.horizon import points_to_pitch_theta  # points_to_hough
 
 
 def log_transforms(transforms: List[BasicTransform], prefix: str) -> None:
@@ -29,7 +30,7 @@ def log_transforms(transforms: List[BasicTransform], prefix: str) -> None:
     )
 
 
-def geometric_augment(imgsz: int) -> List[BasicTransform]:
+def geometric_augment(imgsz: Tuple[int,int]) -> List[BasicTransform]:
     """
     Geometric transforms for augmentation.
     """
@@ -38,7 +39,7 @@ def geometric_augment(imgsz: int) -> List[BasicTransform]:
         Ax.ResizeIfNeeded(max_size=imgsz),
         A.HorizontalFlip(p=0.5),
         A.PadIfNeeded(
-            min_height=imgsz, min_width=imgsz, border_mode=cv2.BORDER_CONSTANT, value=0
+            min_height=imgsz[0], min_width=imgsz[1], border_mode=cv2.BORDER_CONSTANT, value=0
         ),
         A.Affine(
             p=0.75,
@@ -55,7 +56,7 @@ def geometric_augment(imgsz: int) -> List[BasicTransform]:
 
 
 def horizon_augment_rgb(
-    imgsz: int,
+    imgsz: Tuple[int,int],
     im_compression_prob: float,
     prefix=colorstr("albumentations rgb:"),
 ) -> A.Compose:
@@ -63,7 +64,7 @@ def horizon_augment_rgb(
     Augmentations for RGB images.
 
     Args:
-        imgsz (int): image size
+        imgsz (Tuple[int,int]): image size (height, width)
         im_compression_prob (float): Image compression propability
 
     """
@@ -97,20 +98,20 @@ def horizon_augment_rgb(
     )
 
 
-def horizon_base_rgb(imgsz: int) -> A.Compose:
+def horizon_base_rgb(imgsz: Tuple[int,int]) -> A.Compose:
     """
     No augmentation, just resize and normalize.
 
     Args:
-        imgsz (int): image size
+        imgsz  (Tuple[int,int]): image size (height, width)
     """
     return A.Compose(
         [
             # geometric transforms
             Ax.ResizeIfNeeded(max_size=imgsz),
             A.PadIfNeeded(
-                min_height=imgsz,
-                min_width=imgsz,
+                min_height=imgsz[0],
+                min_width=imgsz[1],
                 border_mode=cv2.BORDER_CONSTANT,
                 value=0,
             ),  # letterbox
@@ -123,13 +124,13 @@ def horizon_base_rgb(imgsz: int) -> A.Compose:
 
 
 def horizon_augment_ir16bit(
-    imgsz: int, im_compression_prob: float, prefix=colorstr("albumentations ir16bit:")
+    imgsz: Tuple[int,int], im_compression_prob: float, prefix=colorstr("albumentations ir16bit:")
 ) -> A.Compose:
     """
     Augmentations for 16-bit IR images.
 
     Args:
-        imgsz (int): image size
+        imgsz (Tuple[int,int]): image size (height, width)
         im_compression_prob (float): Image compression propability
     """
 
@@ -154,7 +155,7 @@ def horizon_augment_ir16bit(
 
 
 def horizon_base_ir16bit(
-    imgsz: int,
+    imgsz: Tuple[int,int],
     lower_limit: float = 15000 / 65535,
     upper_limit: float = 28000 / 65535,
     clahe: bool = True,
@@ -164,7 +165,7 @@ def horizon_base_ir16bit(
     No augmentation, just resize and normalize.
 
     Args:
-        imgsz (int): image size
+        imgsz (Tuple[int,int]): image size (height, width)
         lower_limit (float): lower limit for clipping
         upper_limit (float): upper limit for clipping
         clahe (bool): apply CLAHE
@@ -185,8 +186,8 @@ def horizon_base_ir16bit(
             # geometric transforms
             Ax.ResizeIfNeeded(max_size=imgsz),
             A.PadIfNeeded(
-                min_height=imgsz,
-                min_width=imgsz,
+                min_height=imgsz[0],
+                min_width=imgsz[1],
                 border_mode=cv2.BORDER_CONSTANT,
                 value=0,
             ),  # letterbox

--- a/horizon/transforms.py
+++ b/horizon/transforms.py
@@ -36,7 +36,7 @@ def geometric_augment(imgsz: Tuple[int,int]) -> List[BasicTransform]:
     """
     return [
         A.RandomCropFromBorders(p=0.1),
-        Ax.ResizeIfNeeded(max_size=max(imgsz)),
+        Ax.ResizeIfNeeded(max_size_hw=imgsz),
         A.HorizontalFlip(p=0.5),
         A.PadIfNeeded(
             min_height=imgsz[0], min_width=imgsz[1], border_mode=cv2.BORDER_CONSTANT, value=0
@@ -108,7 +108,7 @@ def horizon_base_rgb(imgsz: Tuple[int,int]) -> A.Compose:
     return A.Compose(
         [
             # geometric transforms
-            Ax.ResizeIfNeeded(max_size=min(imgsz)),
+            Ax.ResizeIfNeeded(max_size_hw=imgsz),
             A.PadIfNeeded(
                 min_height=imgsz[0],
                 min_width=imgsz[1],
@@ -184,7 +184,7 @@ def horizon_base_ir16bit(
             A.UnsharpMask(p=1.0 if unsharp_mask else 0.0, threshold=5),
             A.ToRGB(p=1.0),
             # geometric transforms
-            Ax.ResizeIfNeeded(max_size=min(imgsz)),
+            Ax.ResizeIfNeeded(max_size_hw=imgsz),
             A.PadIfNeeded(
                 min_height=imgsz[0],
                 min_width=imgsz[1],

--- a/horizon/transforms.py
+++ b/horizon/transforms.py
@@ -36,7 +36,7 @@ def geometric_augment(imgsz: Tuple[int,int]) -> List[BasicTransform]:
     """
     return [
         A.RandomCropFromBorders(p=0.1),
-        Ax.ResizeIfNeeded(max_size=min(imgsz)),
+        Ax.ResizeIfNeeded(max_size=max(imgsz)),
         A.HorizontalFlip(p=0.5),
         A.PadIfNeeded(
             min_height=imgsz[0], min_width=imgsz[1], border_mode=cv2.BORDER_CONSTANT, value=0
@@ -108,7 +108,7 @@ def horizon_base_rgb(imgsz: Tuple[int,int]) -> A.Compose:
     return A.Compose(
         [
             # geometric transforms
-            Ax.ResizeIfNeeded(max_size=min(imgsz)),
+            Ax.ResizeIfNeeded(max_size=max(imgsz)),
             A.PadIfNeeded(
                 min_height=imgsz[0],
                 min_width=imgsz[1],
@@ -184,7 +184,7 @@ def horizon_base_ir16bit(
             A.UnsharpMask(p=1.0 if unsharp_mask else 0.0, threshold=5),
             A.ToRGB(p=1.0),
             # geometric transforms
-            Ax.ResizeIfNeeded(max_size=min(imgsz)),
+            Ax.ResizeIfNeeded(max_size=max(imgsz)),
             A.PadIfNeeded(
                 min_height=imgsz[0],
                 min_width=imgsz[1],

--- a/horizon/transforms.py
+++ b/horizon/transforms.py
@@ -36,7 +36,7 @@ def geometric_augment(imgsz: Tuple[int,int]) -> List[BasicTransform]:
     """
     return [
         A.RandomCropFromBorders(p=0.1),
-        Ax.ResizeIfNeeded(max_size=imgsz),
+        Ax.ResizeIfNeeded(max_size=min(imgsz)),
         A.HorizontalFlip(p=0.5),
         A.PadIfNeeded(
             min_height=imgsz[0], min_width=imgsz[1], border_mode=cv2.BORDER_CONSTANT, value=0
@@ -108,7 +108,7 @@ def horizon_base_rgb(imgsz: Tuple[int,int]) -> A.Compose:
     return A.Compose(
         [
             # geometric transforms
-            Ax.ResizeIfNeeded(max_size=imgsz),
+            Ax.ResizeIfNeeded(max_size=min(imgsz)),
             A.PadIfNeeded(
                 min_height=imgsz[0],
                 min_width=imgsz[1],
@@ -184,7 +184,7 @@ def horizon_base_ir16bit(
             A.UnsharpMask(p=1.0 if unsharp_mask else 0.0, threshold=5),
             A.ToRGB(p=1.0),
             # geometric transforms
-            Ax.ResizeIfNeeded(max_size=imgsz),
+            Ax.ResizeIfNeeded(max_size=min(imgsz)),
             A.PadIfNeeded(
                 min_height=imgsz[0],
                 min_width=imgsz[1],

--- a/horizon/transforms.py
+++ b/horizon/transforms.py
@@ -36,7 +36,7 @@ def geometric_augment(imgsz: Tuple[int,int]) -> List[BasicTransform]:
     """
     return [
         A.RandomCropFromBorders(p=0.1),
-        Ax.ResizeIfNeeded(max_size=min(imgsz)),
+        Ax.ResizeIfNeeded(max_size=max(imgsz)),
         A.HorizontalFlip(p=0.5),
         A.PadIfNeeded(
             min_height=imgsz[0], min_width=imgsz[1], border_mode=cv2.BORDER_CONSTANT, value=0

--- a/models/custom.py
+++ b/models/custom.py
@@ -60,7 +60,9 @@ class HorizonModel(BaseModel):
             LOGGER.warning("WARNING ⚠️ converting YOLOv5 DetectionModel to HorizonModel")
             self.cutoff = _find_cutoff(model) if cutoff is None else cutoff
             self._from_detection_model(model, self.cutoff)  # inplace modification
-
+            
+        self.model = model.model
+        self.model.to(self.device)
       
         self.model.half() if fp16 else self.model.float()
         self.stride = stride

--- a/models/custom.py
+++ b/models/custom.py
@@ -46,7 +46,8 @@ class HorizonModel(BaseModel):
 
         self.nc_pitch = nc_pitch
         self.nc_theta = nc_theta
-        self.device = torch.device(device)
+        self.device = select_device(device)
+        print(f"Using device: {self.device}")
         self.fp16 = fp16
 
         if Path(weights).is_file() or weights.endswith(".pt"):
@@ -60,7 +61,7 @@ class HorizonModel(BaseModel):
             LOGGER.warning("WARNING ⚠️ converting YOLOv5 DetectionModel to HorizonModel")
             self.cutoff = _find_cutoff(model) if cutoff is None else cutoff
             self._from_detection_model(model, self.cutoff)  # inplace modification
-            
+
         self.model = model.model
         self.model.to(self.device)
       

--- a/models/custom.py
+++ b/models/custom.py
@@ -63,6 +63,7 @@ class HorizonModel(BaseModel):
 
         self.model = model.model
         self.model.to(self.device)
+      
         self.model.half() if fp16 else self.model.float()
         self.stride = stride
         self.save = model.save

--- a/models/custom.py
+++ b/models/custom.py
@@ -46,7 +46,7 @@ class HorizonModel(BaseModel):
 
         self.nc_pitch = nc_pitch
         self.nc_theta = nc_theta
-        self.device = device# select_device(device)
+        self.device = torch.device(device)
         self.fp16 = fp16
 
         if Path(weights).is_file() or weights.endswith(".pt"):

--- a/models/custom.py
+++ b/models/custom.py
@@ -50,7 +50,7 @@ class HorizonModel(BaseModel):
         self.fp16 = fp16
 
         if Path(weights).is_file() or weights.endswith(".pt"):
-            model = attempt_load(weights, device="cpu", fuse=fuse)
+            model = attempt_load(weights, device=device, fuse=fuse)
             stride = model.stride
             LOGGER.info(f"Loaded weights from {weights}")
         else:

--- a/models/custom.py
+++ b/models/custom.py
@@ -50,7 +50,7 @@ class HorizonModel(BaseModel):
         self.fp16 = fp16
 
         if Path(weights).is_file() or weights.endswith(".pt"):
-            model = attempt_load(weights, device=device, fuse=fuse)
+            model = attempt_load(weights, device="cpu", fuse=fuse)
             stride = model.stride
             LOGGER.info(f"Loaded weights from {weights}")
         else:

--- a/models/custom.py
+++ b/models/custom.py
@@ -46,7 +46,7 @@ class HorizonModel(BaseModel):
 
         self.nc_pitch = nc_pitch
         self.nc_theta = nc_theta
-        self.device = select_device(device)
+        self.device = device# select_device(device)
         self.fp16 = fp16
 
         if Path(weights).is_file() or weights.endswith(".pt"):
@@ -61,8 +61,7 @@ class HorizonModel(BaseModel):
             self.cutoff = _find_cutoff(model) if cutoff is None else cutoff
             self._from_detection_model(model, self.cutoff)  # inplace modification
 
-        self.model = model.model
-        self.model.to(self.device)
+      
         self.model.half() if fp16 else self.model.float()
         self.stride = stride
         self.save = model.save

--- a/models/custom.py
+++ b/models/custom.py
@@ -47,7 +47,6 @@ class HorizonModel(BaseModel):
         self.nc_pitch = nc_pitch
         self.nc_theta = nc_theta
         self.device = select_device(device)
-        print(f"Using device: {self.device}")
         self.fp16 = fp16
 
         if Path(weights).is_file() or weights.endswith(".pt"):

--- a/utils/albumextensions.py
+++ b/utils/albumextensions.py
@@ -1,15 +1,14 @@
 """Custom augmentations following the Albumentations API."""
 
 import random
-from typing import Dict, Optional, Tuple, Union, cast, List
+from typing import Dict, List, Optional, Tuple, Union, cast
 
 import cv2
 import numpy as np
 from albumentations.augmentations.geometric import functional as F
 from albumentations.core.pydantic import InterpolationType, ScaleIntType
-from albumentations.core.transforms_interface import DualTransform, BaseTransformInitSchema
-
-from pydantic import field_validator, ValidationInfo
+from albumentations.core.transforms_interface import BaseTransformInitSchema, DualTransform
+from pydantic import ValidationInfo, field_validator
 
 
 class MaxSizeHWInitSchema(BaseTransformInitSchema):
@@ -35,7 +34,7 @@ class MaxSizeHWInitSchema(BaseTransformInitSchema):
             return None
         if not isinstance(v, tuple) or len(v) != 2:
             raise ValueError(f"{info.field_name} must be a tuple of two integers")
-        if not all(x >= 1 for x in v):
+        if any(x < 1 for x in v):
             raise ValueError(f"All values in {info.field_name} must be bigger or equal to 1")
         return v
 

--- a/utils/albumextensions.py
+++ b/utils/albumextensions.py
@@ -24,7 +24,7 @@ class MaxSizeHWInitSchema(BaseTransformInitSchema):
             return None
         result = v if isinstance(v, (list, tuple)) else [v]
         for value in result:
-            if not value >= 1:
+            if value < 1:
                 raise ValueError(f"{info.field_name} must be bigger or equal to 1.")
         return cast(Union[int, List[int], None], result)
 

--- a/utils/albumextensions.py
+++ b/utils/albumextensions.py
@@ -1,22 +1,53 @@
 """Custom augmentations following the Albumentations API."""
 
 import random
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple, Union, cast, List
 
 import cv2
 import numpy as np
 from albumentations.augmentations.geometric import functional as F
-from albumentations.core.transforms_interface import DualTransform
+from albumentations.core.pydantic import InterpolationType, ScaleIntType
+from albumentations.core.transforms_interface import DualTransform, BaseTransformInitSchema
 
-from albumentations.augmentations.geometric.resize import MaxSizeInitSchema
+from pydantic import field_validator, ValidationInfo
+
+
+class MaxSizeHWInitSchema(BaseTransformInitSchema):
+    max_size: int | list[int] | None
+    max_size_hw: tuple[int, int] | None
+    interpolation: InterpolationType
+
+    @field_validator("max_size")
+    @classmethod
+    def check_max_size(cls, v: ScaleIntType | None, info: ValidationInfo) -> int | list[int] | None:
+        if v is None:
+            return None
+        result = v if isinstance(v, (list, tuple)) else [v]
+        for value in result:
+            if not value >= 1:
+                raise ValueError(f"{info.field_name} must be bigger or equal to 1.")
+        return cast(Union[int, List[int], None], result)
+
+    @field_validator("max_size_hw")
+    @classmethod
+    def check_max_size_hw(cls, v: tuple[int, int] | None, info: ValidationInfo) -> tuple[int, int] | None:
+        if v is None:
+            return None
+        if not isinstance(v, tuple) or len(v) != 2:
+            raise ValueError(f"{info.field_name} must be a tuple of two integers")
+        if not all(x >= 1 for x in v):
+            raise ValueError(f"All values in {info.field_name} must be bigger or equal to 1")
+        return v
+
 
 class ResizeIfNeeded(DualTransform):
     """
-    Resize an image if its longest side is greater than a specified value.
+    Resize an image if its dimensions exceed specified maximum values.
 
     Args:
-        max_size (int, list of int): maximum size of the image after the transformation. When using a list, max size
-            will be randomly selected from the values in the list.
+        max_size (int, list of int, optional): maximum size of the longest side of the image after transformation.
+            When using a list, max size will be randomly selected from the values in the list.
+        max_size_hw (tuple of int, optional): maximum height and width of the image after transformation.
         interpolation (OpenCV flag): interpolation method. Default: cv2.INTER_LINEAR.
         p (float): probability of applying the transform. Default: 1.
 
@@ -26,45 +57,86 @@ class ResizeIfNeeded(DualTransform):
     Image types:
         uint8, float32
     """
-    class InitSchema(MaxSizeInitSchema):
+
+    class InitSchema(MaxSizeHWInitSchema):
         pass
 
     def __init__(
         self,
-        max_size: int | None = 1024,
+        max_size: Optional[Union[int, list]] = None,
+        max_size_hw: Optional[Tuple[int, int]] = None,
         interpolation: int = cv2.INTER_LINEAR,
         always_apply: bool = False,
         p: float = 1,
     ):
         super().__init__(p=p, always_apply=always_apply)
-        self.interpolation = interpolation
         self.max_size = max_size
+        self.max_size_hw = max_size_hw
+        self.interpolation = interpolation
+
+        if not any([max_size, max_size_hw]):
+            raise ValueError("At least one of max_size or max_size_hw must be set")
+
+    def _compute_scale(self, height: int, width: int, max_size: Optional[int], max_size_hw: Optional[Tuple[int, int]]) -> float:
+        """Compute the scale factor based on image dimensions and maximum constraints."""
+        scale_height = scale_width = 1.0
+
+        if max_size_hw is not None:
+            max_height, max_width = max_size_hw
+            if height > max_height:
+                scale_height = max_height / height
+            if width > max_width:
+                scale_width = max_width / width
+
+        if max_size is not None and max(height, width) > max_size:
+            scale = max_size / max(height, width)
+            scale_height = scale_width = min(scale_height, scale_width, scale)
+
+        return min(scale_height, scale_width)
 
     def apply(
         self,
         img: np.ndarray,
-        max_size: int = 1024,
+        max_size: Optional[int] = None,
+        max_size_hw: Optional[Tuple[int, int]] = None,
         interpolation: int = cv2.INTER_LINEAR,
         **params,
     ) -> np.ndarray:
-        if max(img.shape[:2]) > max_size:
-            return F.longest_max_size(img, max_size=max_size, interpolation=interpolation)
-        return img  # skip the transformation (don't scale up)
+        height, width = img.shape[:2]
+        final_scale = self._compute_scale(height, width, max_size, max_size_hw)
+
+        if final_scale < 1.0:  # Only resize if we need to scale down
+            new_height = int(height * final_scale)
+            new_width = int(width * final_scale)
+            return cv2.resize(img, (new_width, new_height), interpolation=interpolation)
+
+        return img
 
     def apply_to_bbox(self, bbox: np.ndarray, **params) -> np.ndarray:
         # Bounding box coordinates are scale invariant
         return bbox
 
-    def apply_to_keypoints(self, keypoints: np.ndarray, max_size: int = 1024, **params) -> np.ndarray:
+    def apply_to_keypoints(
+        self,
+        keypoints: np.ndarray,
+        max_size: Optional[int] = None,
+        max_size_hw: Optional[Tuple[int, int]] = None,
+        **params,
+    ) -> np.ndarray:
         height = params["rows"]
         width = params["cols"]
 
-        scale = max_size / max([height, width])
-        scale = min(1.0, scale)  # don't scale up
-        return F.keypoints_scale(keypoints, scale, scale)
+        final_scale = self._compute_scale(height, width, max_size, max_size_hw)
+        final_scale = min(1.0, final_scale)  # don't scale up
 
-    def get_params(self) -> Dict[str, int]:
-        return {"max_size": (self.max_size if isinstance(self.max_size, int) else random.choice(self.max_size))}
+        return F.keypoints_scale(keypoints, final_scale, final_scale)
+
+    def get_params(self) -> Dict[str, Optional[int]]:
+        max_size = None
+        if self.max_size:
+            max_size = self.max_size if isinstance(self.max_size, int) else random.choice(self.max_size)
+
+        return {"max_size": max_size, "max_size_hw": self.max_size_hw}
 
     def get_transform_init_args_names(self) -> Tuple[str, ...]:
-        return ("max_size", "interpolation")
+        return ("max_size", "max_size_hw", "interpolation")

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -55,7 +55,7 @@ def autobatch(model, imgsz=[640, 640], fraction=0.8, batch_size=16):
     # Inspect CUDA memory
     gb = 1 << 30  # bytes to GiB (1024 ** 3)
     d = str(device).upper()  # 'CUDA:0'
-    print_available_devices()   
+    print_available_devices()    
     properties = torch.cuda.get_device_properties(device)  # device properties
     t = properties.total_memory / gb  # GiB total
     r = torch.cuda.memory_reserved(device) / gb  # GiB reserved

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -57,7 +57,7 @@ def autobatch(model, imgsz=[640, 640], fraction=0.8, batch_size=16):
     gb = 1 << 30  # bytes to GiB (1024 ** 3)
     d = str(device).upper()  # 'CUDA:0'
     print_available_devices()    
-    properties = torch.cuda.get_device_properties("cuda:1")  # device properties
+    properties = torch.cuda.get_device_properties(device)  # device properties
     t = properties.total_memory / gb  # GiB total
     r = torch.cuda.memory_reserved(device) / gb  # GiB reserved
     a = torch.cuda.memory_allocated(device) / gb  # GiB allocated
@@ -75,6 +75,7 @@ def autobatch(model, imgsz=[640, 640], fraction=0.8, batch_size=16):
     # Fit a solution
     y = [x[2] for x in results if x]  # memory [2]
     p = np.polyfit(batch_sizes[: len(y)], y, deg=1)  # first degree polynomial fit
+    print(f"{prefix}Batch sizes {batch_sizes[: len(y)]} -> {y} -> {p}")  # debug
     b = int((f * fraction - p[1]) / p[0])  # y intercept (optimal batch size)
     if None in results:  # some sizes failed
         i = results.index(None)  # first fail index

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -10,13 +10,18 @@ from utils.general import LOGGER, colorstr
 from utils.torch_utils import profile
 
 
-def check_train_batch_size(model, imgsz=640, amp=True):
+def check_train_batch_size(model, imgsz=[640, 640], amp=True):
     """Checks and computes optimal training batch size for YOLOv5 model, given image size and AMP setting."""
+
+    # check if imgsize is a single number and convert it to tuple otherwise
+    imgsz = (imgsz, imgsz) if isinstance(imgsz, int) else imgsz
+
+
     with torch.cuda.amp.autocast(amp):
         return autobatch(deepcopy(model).train(), imgsz)  # compute optimal batch size
 
 
-def autobatch(model, imgsz=640, fraction=0.8, batch_size=16):
+def autobatch(model, imgsz=[640, 640], fraction=0.8, batch_size=16):
     """Estimates optimal YOLOv5 batch size using `fraction` of CUDA memory."""
     # Usage:
     #     import torch
@@ -48,7 +53,7 @@ def autobatch(model, imgsz=640, fraction=0.8, batch_size=16):
     # Profile batch sizes
     batch_sizes = [1, 2, 4, 8, 16]
     try:
-        img = [torch.empty(b, 3, imgsz, imgsz) for b in batch_sizes]
+        img = [torch.empty(b, 3, imgsz[0], imgsz[1]) for b in batch_sizes]
         results = profile(img, model, n=3, device=device)
     except Exception as e:
         LOGGER.warning(f"{prefix}{e}")

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -27,6 +27,7 @@ def print_available_devices():
         print(f"Number of GPUs available: {torch.cuda.device_count()}")
         
         # Loop through all available devices and print their properties
+        print(f"Current device: {torch.cuda.current_device()}")
         for device_id in range(torch.cuda.device_count()):
             print(f"\nDevice {device_id}:")
             print(f"  Name: {torch.cuda.get_device_name(device_id)}")
@@ -56,10 +57,10 @@ def autobatch(model, imgsz=[640, 640], fraction=0.8, batch_size=16):
     gb = 1 << 30  # bytes to GiB (1024 ** 3)
     d = str(device).upper()  # 'CUDA:0'
     print_available_devices()    
-    properties = torch.cuda.get_device_properties(device)  # device properties
+    properties = torch.cuda.get_device_properties()  # device properties
     t = properties.total_memory / gb  # GiB total
-    r = torch.cuda.memory_reserved(device) / gb  # GiB reserved
-    a = torch.cuda.memory_allocated(device) / gb  # GiB allocated
+    r = torch.cuda.memory_reserved() / gb  # GiB reserved
+    a = torch.cuda.memory_allocated() / gb  # GiB allocated
     f = t - (r + a)  # GiB free
     LOGGER.info(f"{prefix}{d} ({properties.name}) {t:.2f}G total, {r:.2f}G reserved, {a:.2f}G allocated, {f:.2f}G free")
 

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -12,7 +12,6 @@ from utils.torch_utils import profile
 
 def check_train_batch_size(model, imgsz=640, amp=True):
     """Checks and computes optimal training batch size for YOLOv5 model, given image size and AMP setting."""
-    LOGGER.info(f"AutoBatch: Checking training batch size for {model.__class__.__name__} model, imgsz={imgsz}, amp={amp}")
     with torch.cuda.amp.autocast(amp):
         return autobatch(deepcopy(model).train(), imgsz)  # compute optimal batch size
     

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -12,6 +12,7 @@ from utils.torch_utils import profile
 
 def check_train_batch_size(model, imgsz=640, amp=True):
     """Checks and computes optimal training batch size for YOLOv5 model, given image size and AMP setting."""
+    LOGGER.info(f"AutoBatch: Checking training batch size for {model.__class__.__name__} model, imgsz={imgsz}, amp={amp}")
     with torch.cuda.amp.autocast(amp):
         return autobatch(deepcopy(model).train(), imgsz)  # compute optimal batch size
     

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -19,7 +19,7 @@ def check_train_batch_size(model, imgsz=[640, 640], amp=True):
 
     with torch.cuda.amp.autocast(amp):
         return autobatch(deepcopy(model).train(), imgsz)  # compute optimal batch size
-
+    
 
 def autobatch(model, imgsz=[640, 640], fraction=0.8, batch_size=16):
     """Estimates optimal YOLOv5 batch size using `fraction` of CUDA memory."""
@@ -57,6 +57,7 @@ def autobatch(model, imgsz=[640, 640], fraction=0.8, batch_size=16):
         results = profile(img, model, n=3, device=device)
     except Exception as e:
         LOGGER.warning(f"{prefix}{e}")
+
 
     # Fit a solution
     y = [x[2] for x in results if x]  # memory [2]

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -67,7 +67,7 @@ def autobatch(model, imgsz=[640, 640], fraction=0.8, batch_size=16):
     # Profile batch sizes
     batch_sizes = [1, 2, 4, 8, 16]
     try:
-        img = [torch.empty(b, 3, imgsz[0], imgsz[1]) for b in batch_sizes]
+        img = [torch.empty(b, 3, imgsz[1], imgsz[0]) for b in batch_sizes]
         results = profile(img, model, n=3, device=device)
     except Exception as e:
         LOGGER.warning(f"{prefix}{e}")

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -10,24 +10,22 @@ from utils.general import LOGGER, colorstr
 from utils.torch_utils import profile
 
 
-def check_train_batch_size(model, imgsz=[640, 640], amp=True):
+def check_train_batch_size(model, imgsz=640, amp=True):
     """Checks and computes optimal training batch size for YOLOv5 model, given image size and AMP setting."""
-
-    # check if imgsize is a single number and convert it to tuple otherwise
-    imgsz = (imgsz, imgsz) if isinstance(imgsz, int) else imgsz
-
-
     with torch.cuda.amp.autocast(amp):
         return autobatch(deepcopy(model).train(), imgsz)  # compute optimal batch size
     
 
-def autobatch(model, imgsz=[640, 640], fraction=0.8, batch_size=16):
+def autobatch(model, imgsz=640, fraction=0.8, batch_size=16):
     """Estimates optimal YOLOv5 batch size using `fraction` of CUDA memory."""
     # Usage:
     #     import torch
     #     from utils.autobatch import autobatch
     #     model = torch.hub.load('ultralytics/yolov5', 'yolov5s', autoshape=False)
     #     print(autobatch(model))
+
+    # Change imgsz to tuple if it is a single number
+    imgsz = (imgsz, imgsz) if isinstance(imgsz, int) else imgsz
 
     # Check device
     prefix = colorstr("AutoBatch: ")

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -43,6 +43,8 @@ def autobatch(model, imgsz=[640, 640], fraction=0.8, batch_size=16):
     # Inspect CUDA memory
     gb = 1 << 30  # bytes to GiB (1024 ** 3)
     d = str(device).upper()  # 'CUDA:0'
+    print(f"device in autobatch: {d}")
+    properties = torch.cuda.get_device_properties(1)  # device properties
     properties = torch.cuda.get_device_properties(device)  # device properties
     t = properties.total_memory / gb  # GiB total
     r = torch.cuda.memory_reserved(device) / gb  # GiB reserved

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -19,7 +19,19 @@ def check_train_batch_size(model, imgsz=[640, 640], amp=True):
 
     with torch.cuda.amp.autocast(amp):
         return autobatch(deepcopy(model).train(), imgsz)  # compute optimal batch size
-
+    
+def print_available_devices():
+    # Check if CUDA is available
+    if torch.cuda.is_available():
+        # Print the number of available GPUs
+        print(f"Number of GPUs available: {torch.cuda.device_count()}")
+        
+        # Loop through all available devices and print their properties
+        for device_id in range(torch.cuda.device_count()):
+            print(f"\nDevice {device_id}:")
+            print(f"  Name: {torch.cuda.get_device_name(device_id)}")
+    else:
+        print("CUDA is not available. No GPU found.")
 
 def autobatch(model, imgsz=[640, 640], fraction=0.8, batch_size=16):
     """Estimates optimal YOLOv5 batch size using `fraction` of CUDA memory."""
@@ -43,8 +55,7 @@ def autobatch(model, imgsz=[640, 640], fraction=0.8, batch_size=16):
     # Inspect CUDA memory
     gb = 1 << 30  # bytes to GiB (1024 ** 3)
     d = str(device).upper()  # 'CUDA:0'
-    print(f"device in autobatch: {d}")
-    properties = torch.cuda.get_device_properties(1)  # device properties
+    print_available_devices()   
     properties = torch.cuda.get_device_properties(device)  # device properties
     t = properties.total_memory / gb  # GiB total
     r = torch.cuda.memory_reserved(device) / gb  # GiB reserved

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -20,19 +20,6 @@ def check_train_batch_size(model, imgsz=[640, 640], amp=True):
     with torch.cuda.amp.autocast(amp):
         return autobatch(deepcopy(model).train(), imgsz)  # compute optimal batch size
     
-def print_available_devices():
-    # Check if CUDA is available
-    if torch.cuda.is_available():
-        # Print the number of available GPUs
-        print(f"Number of GPUs available: {torch.cuda.device_count()}")
-        
-        # Loop through all available devices and print their properties
-        print(f"Current device: {torch.cuda.current_device()}")
-        for device_id in range(torch.cuda.device_count()):
-            print(f"\nDevice {device_id}:")
-            print(f"  Name: {torch.cuda.get_device_name(device_id)}")
-    else:
-        print("CUDA is not available. No GPU found.")
 
 def autobatch(model, imgsz=[640, 640], fraction=0.8, batch_size=16):
     """Estimates optimal YOLOv5 batch size using `fraction` of CUDA memory."""
@@ -56,7 +43,6 @@ def autobatch(model, imgsz=[640, 640], fraction=0.8, batch_size=16):
     # Inspect CUDA memory
     gb = 1 << 30  # bytes to GiB (1024 ** 3)
     d = str(device).upper()  # 'CUDA:0'
-    print_available_devices()    
     properties = torch.cuda.get_device_properties(device)  # device properties
     t = properties.total_memory / gb  # GiB total
     r = torch.cuda.memory_reserved(device) / gb  # GiB reserved
@@ -72,13 +58,10 @@ def autobatch(model, imgsz=[640, 640], fraction=0.8, batch_size=16):
     except Exception as e:
         LOGGER.warning(f"{prefix}{e}")
 
-    # Check results
-    print(f"Results: {results}")  # debug
 
     # Fit a solution
     y = [x[2] for x in results if x]  # memory [2]
     p = np.polyfit(batch_sizes[: len(y)], y, deg=1)  # first degree polynomial fit
-    print(f"{prefix}Batch sizes {batch_sizes[: len(y)]} -> {y} -> {p}")  # debug
     b = int((f * fraction - p[1]) / p[0])  # y intercept (optimal batch size)
     if None in results:  # some sizes failed
         i = results.index(None)  # first fail index

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -67,10 +67,13 @@ def autobatch(model, imgsz=[640, 640], fraction=0.8, batch_size=16):
     # Profile batch sizes
     batch_sizes = [1, 2, 4, 8, 16]
     try:
-        img = [torch.empty(b, 3, imgsz[1], imgsz[0]) for b in batch_sizes]
+        img = [torch.empty(b, 3, imgsz[0], imgsz[1]) for b in batch_sizes]
         results = profile(img, model, n=3, device=device)
     except Exception as e:
         LOGGER.warning(f"{prefix}{e}")
+
+    # Check results
+    print(f"Results: {results}")  # debug
 
     # Fit a solution
     y = [x[2] for x in results if x]  # memory [2]

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -57,10 +57,10 @@ def autobatch(model, imgsz=[640, 640], fraction=0.8, batch_size=16):
     gb = 1 << 30  # bytes to GiB (1024 ** 3)
     d = str(device).upper()  # 'CUDA:0'
     print_available_devices()    
-    properties = torch.cuda.get_device_properties()  # device properties
+    properties = torch.cuda.get_device_properties("cuda:1")  # device properties
     t = properties.total_memory / gb  # GiB total
-    r = torch.cuda.memory_reserved() / gb  # GiB reserved
-    a = torch.cuda.memory_allocated() / gb  # GiB allocated
+    r = torch.cuda.memory_reserved(device) / gb  # GiB reserved
+    a = torch.cuda.memory_allocated(device) / gb  # GiB allocated
     f = t - (r + a)  # GiB free
     LOGGER.info(f"{prefix}{d} ({properties.name}) {t:.2f}G total, {r:.2f}G reserved, {a:.2f}G allocated, {f:.2f}G free")
 

--- a/utils/horizon.py
+++ b/utils/horizon.py
@@ -142,13 +142,15 @@ def scale_line_edges(
 
 
 def slope_intercept_to_points(m: float, b: float, w: int = 1, h: int = 1):
+    # to m, b in normalised space
     if m == np.inf:
-        x_1, y_1 = b * h, 0
-        x_2, y_2 = b * h, h
+        x_1, y_1 = b, 0
+        x_2, y_2 = b, 1
     else:
-        x_1, y_1 = 0, b * h
-        x_2, y_2 = w, m * w + b * h
-    return (x_1, y_1), (x_2, y_2)
+        x_1, y_1 = 0, b
+        x_2, y_2 = 1, m + b
+    # scale to image space
+    return (x_1 * w, y_1 * h), (x_2 * w, y_2 * h)
 
 
 def points_to_hough(x_1, y_1, x_2, y_2):

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -134,7 +134,7 @@ def select_device(device="", batch_size=0, newline=True):
         for i, d in enumerate(devices):
             p = torch.cuda.get_device_properties(i)
             s += f"{'' if i == 0 else space}CUDA:{d} ({p.name}, {p.total_memory / (1 << 20):.0f}MiB)\n"  # bytes to MB
-        arg = "cuda:0"
+        arg = f"cuda:{device}"  # default CUDA device
     elif mps and getattr(torch, "has_mps", False) and torch.backends.mps.is_available():  # prefer MPS if available
         s += "MPS\n"
         arg = "mps"
@@ -144,6 +144,7 @@ def select_device(device="", batch_size=0, newline=True):
 
     if not newline:
         s = s.rstrip()
+
     LOGGER.info(s)
     return torch.device(arg)
 

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -170,7 +170,6 @@ def profile(input, ops, n=10, device=None):
     if not isinstance(device, torch.device):
         device = select_device(device)
     
-    print(f"👩‍💻 Using device: {device}")
     print(
         f"{'Params':>12s}{'GFLOPs':>12s}{'GPU_mem (GB)':>14s}{'forward (ms)':>14s}{'backward (ms)':>14s}"
         f"{'input':>24s}{'output':>24s}"

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -134,7 +134,7 @@ def select_device(device="", batch_size=0, newline=True):
         for i, d in enumerate(devices):
             p = torch.cuda.get_device_properties(i)
             s += f"{'' if i == 0 else space}CUDA:{d} ({p.name}, {p.total_memory / (1 << 20):.0f}MiB)\n"  # bytes to MB
-        arg = "cuda:0"
+        arg = f"cuda:{device}"  # default CUDA device
     elif mps and getattr(torch, "has_mps", False) and torch.backends.mps.is_available():  # prefer MPS if available
         s += "MPS\n"
         arg = "mps"

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -198,7 +198,7 @@ def profile(input, ops, n=10, device=None):
                         t[2] = float("nan")
                     tf += (t[1] - t[0]) * 1000 / n  # ms per op forward
                     tb += (t[2] - t[1]) * 1000 / n  # ms per op backward
-                mem = torch.cuda.memory_reserved(device) / 1e9 if torch.cuda.is_available() else 0  # (GB)
+                mem = torch.cuda.memory_reserved() / 1e9 if torch.cuda.is_available() else 0  # (GB)
                 s_in, s_out = (tuple(x.shape) if isinstance(x, torch.Tensor) else "list" for x in (x, y))  # shapes
                 p = sum(x.numel() for x in m.parameters()) if isinstance(m, nn.Module) else 0  # parameters
                 print(f"{p:12}{flops:12.4g}{mem:>14.3f}{tf:14.4g}{tb:14.4g}{str(s_in):>24s}{str(s_out):>24s}")

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -120,7 +120,7 @@ def select_device(device="", batch_size=0, newline=True):
     if cpu or mps:
         os.environ["CUDA_VISIBLE_DEVICES"] = "-1"  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
-        os.environ["CUDA_VISIBLE_DEVICES"] = device  # set environment variable - must be before assert is_available()
+        #os.environ["CUDA_VISIBLE_DEVICES"] = device  # set environment variable - must be before assert is_available()
         assert torch.cuda.is_available() and torch.cuda.device_count() >= len(device.replace(",", "")), (
             f"Invalid CUDA '--device {device}' requested, use '--device cpu' or pass valid CUDA device(s)"
         )

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -120,7 +120,9 @@ def select_device(device="", batch_size=0, newline=True):
     if cpu or mps:
         os.environ["CUDA_VISIBLE_DEVICES"] = "-1"  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
-        os.environ["CUDA_VISIBLE_DEVICES"] = device  # set environment variable - must be before assert is_available()
+        # Generate comma-separated list of GPU indices (0 to gpu_index)
+        visible_gpus = ",".join(str(i) for i in range(int(device) + 1))
+        os.environ["CUDA_VISIBLE_DEVICES"] = visible_gpus  # set environment variable - must be before assert is_available()
         assert torch.cuda.is_available() and torch.cuda.device_count() >= len(device.replace(",", "")), (
             f"Invalid CUDA '--device {device}' requested, use '--device cpu' or pass valid CUDA device(s)"
         )
@@ -167,6 +169,7 @@ def profile(input, ops, n=10, device=None):
     results = []
     if not isinstance(device, torch.device):
         device = select_device(device)
+    
     print(
         f"{'Params':>12s}{'GFLOPs':>12s}{'GPU_mem (GB)':>14s}{'forward (ms)':>14s}{'backward (ms)':>14s}"
         f"{'input':>24s}{'output':>24s}"
@@ -197,7 +200,7 @@ def profile(input, ops, n=10, device=None):
                         t[2] = float("nan")
                     tf += (t[1] - t[0]) * 1000 / n  # ms per op forward
                     tb += (t[2] - t[1]) * 1000 / n  # ms per op backward
-                mem = torch.cuda.memory_reserved() / 1e9 if torch.cuda.is_available() else 0  # (GB)
+                mem = torch.cuda.memory_reserved(device) / 1e9 if torch.cuda.is_available() else 0  # (GB)
                 s_in, s_out = (tuple(x.shape) if isinstance(x, torch.Tensor) else "list" for x in (x, y))  # shapes
                 p = sum(x.numel() for x in m.parameters()) if isinstance(m, nn.Module) else 0  # parameters
                 print(f"{p:12}{flops:12.4g}{mem:>14.3f}{tf:14.4g}{tb:14.4g}{str(s_in):>24s}{str(s_out):>24s}")

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -144,8 +144,7 @@ def select_device(device="", batch_size=0, newline=True):
 
     if not newline:
         s = s.rstrip()
-        
-    print(f"💻 Running on device: {arg}.")
+
     LOGGER.info(s)
     return torch.device(arg)
 

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -144,6 +144,8 @@ def select_device(device="", batch_size=0, newline=True):
 
     if not newline:
         s = s.rstrip()
+        
+    print(f"💻 Running on device: {arg}.")
     LOGGER.info(s)
     return torch.device(arg)
 

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -120,7 +120,9 @@ def select_device(device="", batch_size=0, newline=True):
     if cpu or mps:
         os.environ["CUDA_VISIBLE_DEVICES"] = "-1"  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
-        #os.environ["CUDA_VISIBLE_DEVICES"] = device  # set environment variable - must be before assert is_available()
+        # Generate comma-separated list of GPU indices (0 to gpu_index)
+        visible_gpus = ",".join(str(i) for i in range(int(device) + 1))
+        os.environ["CUDA_VISIBLE_DEVICES"] = visible_gpus  # set environment variable - must be before assert is_available()
         assert torch.cuda.is_available() and torch.cuda.device_count() >= len(device.replace(",", "")), (
             f"Invalid CUDA '--device {device}' requested, use '--device cpu' or pass valid CUDA device(s)"
         )

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -169,6 +169,8 @@ def profile(input, ops, n=10, device=None):
     results = []
     if not isinstance(device, torch.device):
         device = select_device(device)
+    
+    print(f"👩‍💻 Using device: {device}")
     print(
         f"{'Params':>12s}{'GFLOPs':>12s}{'GPU_mem (GB)':>14s}{'forward (ms)':>14s}{'backward (ms)':>14s}"
         f"{'input':>24s}{'output':>24s}"
@@ -199,7 +201,7 @@ def profile(input, ops, n=10, device=None):
                         t[2] = float("nan")
                     tf += (t[1] - t[0]) * 1000 / n  # ms per op forward
                     tb += (t[2] - t[1]) * 1000 / n  # ms per op backward
-                mem = torch.cuda.memory_reserved() / 1e9 if torch.cuda.is_available() else 0  # (GB)
+                mem = torch.cuda.memory_reserved(device) / 1e9 if torch.cuda.is_available() else 0  # (GB)
                 s_in, s_out = (tuple(x.shape) if isinstance(x, torch.Tensor) else "list" for x in (x, y))  # shapes
                 p = sum(x.numel() for x in m.parameters()) if isinstance(m, nn.Module) else 0  # parameters
                 print(f"{p:12}{flops:12.4g}{mem:>14.3f}{tf:14.4g}{tb:14.4g}{str(s_in):>24s}{str(s_out):>24s}")

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -120,9 +120,7 @@ def select_device(device="", batch_size=0, newline=True):
     if cpu or mps:
         os.environ["CUDA_VISIBLE_DEVICES"] = "-1"  # force torch.cuda.is_available() = False
     elif device:  # non-cpu device requested
-        # Generate comma-separated list of GPU indices (0 to gpu_index)
-        visible_gpus = ",".join(str(i) for i in range(int(device) + 1))
-        os.environ["CUDA_VISIBLE_DEVICES"] = visible_gpus  # set environment variable - must be before assert is_available()
+        os.environ["CUDA_VISIBLE_DEVICES"] = device  # set environment variable - must be before assert is_available()
         assert torch.cuda.is_available() and torch.cuda.device_count() >= len(device.replace(",", "")), (
             f"Invalid CUDA '--device {device}' requested, use '--device cpu' or pass valid CUDA device(s)"
         )
@@ -136,7 +134,7 @@ def select_device(device="", batch_size=0, newline=True):
         for i, d in enumerate(devices):
             p = torch.cuda.get_device_properties(i)
             s += f"{'' if i == 0 else space}CUDA:{d} ({p.name}, {p.total_memory / (1 << 20):.0f}MiB)\n"  # bytes to MB
-        arg = f"cuda:{device}"  # default CUDA device
+        arg = "cuda:0"
     elif mps and getattr(torch, "has_mps", False) and torch.backends.mps.is_available():  # prefer MPS if available
         s += "MPS\n"
         arg = "mps"


### PR DESCRIPTION
## What?
 
Add support for horizon training when the input size is not square.

 
## Why?
 
We want to also train horizon model with not square inputs.
 
## How?

> [!WARNING]  
> Because I had to do a lot of testing, the commit history ended up being a mess. I squashed the commits to clean it, but since I'm not always the brightest star in the universe, I forgot to force push. As a result, we now have both the individual commits and the squashed ones 🫠🫠🫠.
> **I have linked the commits that contain the actual changes to make it a bit better 🙃.**
 
### Handling Input Size

If `imgsz` is provided as a single integer, it will be converted into a `tuple` with equal width and height.
This conversion is necessary for the `horizon.train.run(**train_args)` and also for the  `check_train_batch_size()` function, as other training codes also rely on this logic (but maybe there is a better way 💡)

**Example**

```python
# Ensure imgsz is a tuple (height, width)
imgsz = (imgsz, imgsz) if isinstance(imgsz, int) else imgsz
```

### Modifying the Horizon Dataloader for Non-Square Inputs
Instead of assuming square dimensions, explicitly set `height` and `width`.

**Example (Assumes Square Input)**

```python
A.PadIfNeeded(
    min_height=imgsz, min_width=imgsz, border_mode=cv2.BORDER_CONSTANT, value=0
)
```

**After (Handles Rectangular Inputs)**
```python
A.PadIfNeeded(
    min_height=imgsz[0], min_width=imgsz[1], border_mode=cv2.BORDER_CONSTANT, value=0
)
```

> [!CAUTION]
> **Uncertain Part: A.ResizeIfNeeded(max_size=max(imgsz))**
> I used `max(imgsz)` because chatty said: Use `max(imgsz)` if you want to resize while ensuring neither dimension exceeds the limit. This keeps the aspect ratio intact and ensures the image does not become larger than the specified max size.
> **but not sure about this**

### Additional Bugfixes  

- If the batch size was not `640`, it would always default to `16`.  
  - This was fixed by removing the condition. 
  - [commit](https://github.com/SEA-AI/yolov5/commit/01843c414b1e9dfbb666a696431b8675850142cd)

- CUDA device selection was not working because the device was hardcoded to `cuda:0`.  
  - Now, the selected device is properly returned in the `select_device()` method.  
  - [commit](https://github.com/SEA-AI/yolov5/commit/2c42e5a34debfea922a3f18088be9816e72061e7)

- Issue with `os.environ["CUDA_VISIBLE_DEVICES"] = device`:  
  - If a GPU with `idx=1` was selected, it was set as the only visible GPU.  
  - However, when using automatic GPU selection, accessing device properties via:  
    ```python
    properties = torch.cuda.get_device_properties(device)  # device properties
    ```  
    would fail because **if only one GPU is visible, its index becomes `0`, not `1`**.  
  - This was fixed by always exposing all GPUs up to the selected index, preventing issues with reordered indices.  
    - For example, if `gpu=1` is selected, both `0` and `1` are exposed.
    - [commit](https://github.com/SEA-AI/yolov5/commit/21f5368304dd023de57293a5bdbde744776d3de5)

- Auto batch size calculation was incorrect because GPU `0` was always used.  
  - Now, the correct device is passed, ensuring accurate memory calculations:  
    ```python
    mem = torch.cuda.memory_reserved(device) / 1e9 if torch.cuda.is_available() else 0  # (GB)
    ```
    - [commit](https://github.com/SEA-AI/yolov5/commit/21f5368304dd023de57293a5bdbde744776d3de5)




## Backout plan

Revert this changes.

 
## Testing



 
A training was started with size `(960x1280)`.
[W&B run](https://wandb.ai/sea-ai/yolo-horizon/runs/rh0kjf76?nw=nwuserseaaimlops)

