### PR TITLE
CV-317: Support rectangular input for AHOY export

### DIFF
--- a/export_ahoy.py
+++ b/export_ahoy.py
@@ -103,7 +103,7 @@ def _transform_imgsz(imgsz: int | List[int] | Tuple[int,int]) -> Tuple[int,int]:
 def main(
     det_weights: str,
     hor_weights: str,
-    imgsz: Tuple[int, int],
+    imgsz: int | Tuple[int, int],
     batch_size: int,
     half: bool,
     fuse: bool,

--- a/export_ahoy.py
+++ b/export_ahoy.py
@@ -32,9 +32,11 @@ Example:
 NOTE: For TensorRT 7 compatible models, use the --trt7-compatible flag.
 """
 
-import logging
 import argparse
+import logging
 from pathlib import Path
+from typing import Tuple
+
 import torch
 
 from export import export_onnx, export_onnx_trt7_compatible
@@ -79,7 +81,7 @@ def get_weights_path(weights_path: str) -> str:
 def main(
     det_weights: str,
     hor_weights: str,
-    imgsz: int,
+    imgsz: Tuple[int, int],
     batch_size: int,
     half: bool,
     fuse: bool,
@@ -87,6 +89,9 @@ def main(
     fname: str = "",
 ):
     """Export the model to TensorRT engine."""
+    # If imgsz is a single value, height and width are the same
+    imgsz = imgsz * 2 if len(imgsz) == 1 else imgsz
+
     det_weights = get_weights_path(det_weights)
     hor_weights = get_weights_path(hor_weights)
 
@@ -98,7 +103,8 @@ def main(
     )
 
     if not fname:
-        fname = f"{type(model).__name__.lower()}_b{batch_size}_sz{imgsz}.onnx"
+        input_size = f"{imgsz[0]}x{imgsz[1]}"
+        fname = f"{type(model).__name__.lower()}_b{batch_size}_sz{input_size}.onnx"
     print(f"🚀 Exporting model {type(model).__name__} to {fname}...")
 
     inplace = False  # default
@@ -115,7 +121,7 @@ def main(
     model.register_io_hooks()  # inp: uint8 -> fp32/fp16 / 255.0, out: fp16 -> fp32
 
     # Create dummy input
-    image = torch.zeros((batch_size, 3, imgsz, imgsz), device=model.device).byte()
+    image = torch.zeros((batch_size, 3, imgsz[0], imgsz[1]), device=model.device).byte() # B, C, H, W
     # https://github.com/NVIDIA/TensorRT/issues/3026#issuecomment-1570419758
     image = image.float() if trt7_compatible else image
     print(f"🔮 Dummy input...{image.shape}, {image.dtype}")
@@ -153,9 +159,10 @@ def _parse_args():
     parser.add_argument(
         "-sz",
         "--imgsz",
-        type=int,
-        default=640,
-        help="Image size (square).",
+        nargs="+", 
+        type=int, 
+        default=[640, 640], 
+        help="image (h, w)"
     )
     parser.add_argument(
         "-bs",

--- a/export_ahoy.py
+++ b/export_ahoy.py
@@ -35,7 +35,7 @@ NOTE: For TensorRT 7 compatible models, use the --trt7-compatible flag.
 import argparse
 import logging
 from pathlib import Path
-from typing import Tuple
+from typing import List, Tuple
 
 import torch
 
@@ -76,7 +76,37 @@ def get_weights_path(weights_path: str) -> str:
     except Exception as e:
         logging.error(f"Failed to download from W&B: {str(e)}")
         raise e
+    
 
+def _transform_imgsz(imgsz: int | List[int] | Tuple[int,int]) -> Tuple[int,int]:
+    """
+    Convert size specifications to (height, width) tuple format.
+    
+    Args:
+        input_size: Int, list, or tuple representing dimensions.
+            - If int: converted to (input_size, input_size)
+            - If list/tuple with single element: converted to (element, element)
+            - If list/tuple with exactly 2 elements: converted to (element1, element2)
+    
+    Returns:
+        Tuple in (height, width) format.
+        
+    Raises:
+        ValueError: If input_size has more than 2 elements or cannot be converted.
+    """
+    # Handle scalar case (single integer)
+
+    if isinstance(imgsz, int):
+        return (imgsz, imgsz)
+    
+    # Handle sequence cases
+    if isinstance(imgsz, (list, tuple)):
+        if len(imgsz) == 1:
+            return (imgsz[0], imgsz[0])
+        elif len(imgsz) == 2:
+            return (imgsz[0], imgsz[1])
+        else:
+            raise ValueError(f"Input size must have 1 or 2 elements, got {len(imgsz)}")
 
 def main(
     det_weights: str,
@@ -89,8 +119,8 @@ def main(
     fname: str = "",
 ):
     """Export the model to TensorRT engine."""
-    # If imgsz is a single value, height and width are the same
-    imgsz = imgsz * 2 if len(imgsz) == 1 else imgsz
+    # Transform image size to (height, width) format
+    imgsz = _transform_imgsz(imgsz)
 
     det_weights = get_weights_path(det_weights)
     hor_weights = get_weights_path(hor_weights)

--- a/export_ahoy.py
+++ b/export_ahoy.py
@@ -83,30 +83,22 @@ def _transform_imgsz(imgsz: int | List[int] | Tuple[int,int]) -> Tuple[int,int]:
     Convert size specifications to (height, width) tuple format.
     
     Args:
-        input_size: Int, list, or tuple representing dimensions.
-            - If int: converted to (input_size, input_size)
-            - If list/tuple with single element: converted to (element, element)
-            - If list/tuple with exactly 2 elements: converted to (element1, element2)
+        imgsz: Int, list, or tuple representing dimensions.
+            - If int: converted to (imgsz, imgsz)
+            - If list/tuple with 1 or 2 elements: converted to (imgsz[0], imgsz[-1])
     
     Returns:
         Tuple in (height, width) format.
         
     Raises:
-        ValueError: If input_size has more than 2 elements or cannot be converted.
+        ValueError: If imgsz is not int, list, or tuple, or if list/tuple has more than 2 elements.
     """
     # Handle scalar case (single integer)
-
     if isinstance(imgsz, int):
-        return (imgsz, imgsz)
-    
-    # Handle sequence cases
-    if isinstance(imgsz, (list, tuple)):
-        if len(imgsz) == 1:
-            return (imgsz[0], imgsz[0])
-        elif len(imgsz) == 2:
-            return (imgsz[0], imgsz[1])
-        else:
-            raise ValueError(f"Input size must have 1 or 2 elements, got {len(imgsz)}")
+        return imgsz, imgsz
+    if not isinstance(imgsz, (list, tuple)) or len(imgsz) not in (1, 2):
+        raise ValueError(f"imgsz must be int or a list/tuple of 1 or 2 elements, got {imgsz}")
+    return imgsz[0], imgsz[-1]
 
 def main(
     det_weights: str,


### PR DESCRIPTION
## What?
 
Support rectangular input shapes when exporting an AHOY model.

## Why?
 
Currently, just square input shapes are used in our products, but this will change in the future. This changes enable support for rectangular input shapes.

## How?

`imgsz` can now be a `tuple` of `(height, width)`, allowing for rectangular input shapes instead of just supporting square dimensions.

Previously, `imgsz` was treated as a single value and used to create a square dummy input tensor when exporting the model. Now, the export process correctly supports rectangular input shapes by handling `imgsz ` as a `(height, width)` tuple.

#### Before
Before, `imgsz` was used to create a dummy input tensor, assuming it was always square:

```python
# Create dummy input  
image = torch.zeros((batch_size, 3, imgsz, imgsz), device=model.device).byte()  # B, C, H, W  
```

#### Now
Now, `imgsz` is correctly interpreted as `(height, width)`, allowing for non-square inputs:

```python
# Create dummy input  
image = torch.zeros((batch_size, 3, imgsz[0], imgsz[1]), device=model.device).byte()  # B, C, H, W  
```

#### `imgsz` Helper Function
A helper function `_transform_imgsz` was introduced to ensure robust handling of input sizes:

- If int: converted to (imgsz, imgsz)
- If list/tuple with one element: converted to (element, element)
-  If list/tuple with two elements: converted to (element1, element2)

#### Updated Naming Convention

The exported file name now follows this format:
`ahoy_{bz}_sz{h}x{w}.onnx`

## Backout plan

Revert the changes
 
## Testing
AHOY model was exported.

<img width="1410" alt="image" src="https://github.com/user-attachments/assets/03971e06-1b79-4dd5-8898-2ae320c4f76a" />

Input size is really rectangular.
<img width="1284" alt="image" src="https://github.com/user-attachments/assets/7249d146-112a-42e0-89f2-5856bba19a97" />


Inference is still working :)
![image](https://github.com/user-attachments/assets/4409b637-725b-4020-b07a-0aaa1900535f)


