### PR TITLE
CV-336: GPU Preprocessing inside Model's Graph

### DIFF
--- a/export_ahoy.py
+++ b/export_ahoy.py
@@ -14,13 +14,14 @@ Example:
         --det-weights yolov5n.pt \
         --hor-weights yolov5h.pt \
         --imgsz 640 \
+        --infsz 320
         --batch-size 2 \
         --fuse \
         --half \
         --fname ahoy.onnx
 
 # flatten this
-    python export_ahoy.py --det-weights yolov5n.pt --hor-weights yolov5h.pt imgsz 640 --batch-size 2 --fuse --half --fname ahoy.onnx
+    python export_ahoy.py --det-weights yolov5n.pt --hor-weights yolov5h.pt --imgsz 640 --infsz 320 --batch-size 2 --fuse --half --fname ahoy.onnx
 
 
     # Using W&B artifacts:
@@ -82,7 +83,7 @@ def get_weights_path(weights_path: str) -> str:
         raise e
     
 
-def _transform_imgsz(imgsz: int | List[int] | Tuple[int,int]) -> Tuple[int,int]:
+def _transform_sz(imgsz: int | List[int] | Tuple[int,int]) -> Tuple[int,int]:
     """
     Convert size specifications to (height, width) tuple format.
     
@@ -108,6 +109,7 @@ def main(
     det_weights: str,
     hor_weights: str,
     imgsz: int | Tuple[int, int],
+    infsz: int | Tuple[int, int],
     batch_size: int,
     half: bool,
     fuse: bool,
@@ -116,8 +118,9 @@ def main(
 ):
     """Export the model to TensorRT engine."""
     # Transform image size to (height, width) format
-    imgsz = _transform_imgsz(imgsz)
-
+    imgsz = _transform_sz(imgsz)
+    infsz = _transform_sz(infsz)
+    print("main", imgsz, infsz)
     det_weights = get_weights_path(det_weights)
     hor_weights = get_weights_path(hor_weights)
 
@@ -126,6 +129,8 @@ def main(
         hor_det_weights=hor_weights,
         fp16=half,
         fuse=fuse,
+        imgsz=imgsz,
+        infsz=infsz,
     )
 
     if not fname:
@@ -188,7 +193,14 @@ def _parse_args():
         nargs="+", 
         type=int, 
         default=[640, 640], 
-        help="image (h, w)"
+        help="image input shape (h, w)"
+    )
+    parser.add_argument(
+        "--infsz",
+        nargs="+", 
+        type=int, 
+        default=[640, 640], 
+        help="image shape during inference (h, w)"
     )
     parser.add_argument(
         "-bs",

--- a/export_ahoy.py
+++ b/export_ahoy.py
@@ -19,6 +19,10 @@ Example:
         --half \
         --fname ahoy.onnx
 
+# flatten this
+    python export_ahoy.py --det-weights yolov5n.pt --hor-weights yolov5h.pt imgsz 640 --batch-size 2 --fuse --half --fname ahoy.onnx
+
+
     # Using W&B artifacts:
     python export_ahoy.py \
         --det-weights YOLOv5n-IR:latest \

--- a/export_ahoy.py
+++ b/export_ahoy.py
@@ -120,7 +120,6 @@ def main(
     # Transform image size to (height, width) format
     imgsz = _transform_sz(imgsz)
     infsz = _transform_sz(infsz)
-    print("main", imgsz, infsz)
     det_weights = get_weights_path(det_weights)
     hor_weights = get_weights_path(hor_weights)
 

--- a/models/custom.py
+++ b/models/custom.py
@@ -4,6 +4,7 @@ from typing import Union
 import numpy as np
 import torch
 from torch import nn
+from torchvision import transforms
 
 from models.common import Classify, DetectMultiBackend
 from models.experimental import attempt_load
@@ -255,6 +256,7 @@ class ObjectsModel(BaseModel):
         self.save = model.save
 
 
+
 class AHOY(nn.Module):
     """A H-orizon O-bject detection Y-OLOv5."""
 
@@ -278,6 +280,14 @@ class AHOY(nn.Module):
 
         # keep track of hooks
         self.hooks = {}
+
+        self.pad_left, self.pad_right, self.pad_top, self.pad_bottom = self.get_padding_for_aspect_ratio(1080, 3600, 640, 1280)
+        self.ratio = max(1080/640, 3600/1280)
+        print("PADS", self.pad_left, self.pad_right, self.pad_top, self.pad_bottom)
+        self.transform = transforms.Compose([
+            transforms.Resize((640-self.pad_top-self.pad_bottom, 1280-self.pad_left-self.pad_right), interpolation=transforms.InterpolationMode.NEAREST, antialias=False),
+            transforms.Pad(padding=(self.pad_left, self.pad_top, self.pad_right, self.pad_bottom), fill = 0, padding_mode="constant")
+        ])
 
     def forward(self, x, profile=False, visualize=False):
         """Forward pass through models."""
@@ -309,18 +319,39 @@ class AHOY(nn.Module):
         self.hooks.clear()
 
     @staticmethod
+    def get_padding_for_aspect_ratio(h_in, w_in, h_out, w_out):
+        """
+        Calculates padding (left, right, top, bottom) needed after resizing
+        while preserving aspect ratio to fit exactly into (h_out, w_out).
+        """
+        scale = min(h_out / h_in, w_out / w_in)
+        new_h = int(h_in * scale)
+        new_w = int(w_in * scale)
+
+        pad_h = h_out - new_h
+        pad_w = w_out - new_w
+
+        pad_top = pad_h // 2
+        pad_bottom = pad_h - pad_top
+        pad_left = pad_w // 2
+        pad_right = pad_w - pad_left
+
+        return pad_left, pad_right, pad_top, pad_bottom
+
+    @staticmethod
     def _preprocessing_hook(module, inputs):
         """Add preprocessing operations to be part of the model."""
 
         def _preprocess(x):
-            if not isinstance(x, torch.Tensor):
+            if len(x.shape) <1 :
                 return x
+            x = x.float()
+            x = module.transform(x)
             x = x.half() if module.fp16 else x.float()
             x = x / 255.0  # 0-255 to 0.0-1.0
             return x
 
         return tuple(_preprocess(inp) for inp in inputs)
-
 
     @staticmethod
     def _postprocessing_hook(module, inputs, outputs):
@@ -331,7 +362,12 @@ class AHOY(nn.Module):
 
         # ahoy outputs: (tuple(Tensor, ...), Tensor, Tensor)
         first_tuple, second_item, third_item = outputs
-
+        # print(first_tuple[0].shape)
+        # print(first_tuple[0][0,0,:])
+        first_tuple[0][:,:,0] -= module.pad_left
+        first_tuple[0][:,:,1] -= module.pad_top
+        first_tuple[0][:,:,:4] *= module.ratio 
+        # print(first_tuple[0][0,0,:])
         # Only convert the first item of the first tuple (the detection outputs)
         first_tuple = (_to_float(first_tuple[0]),) + first_tuple[1:]
 

--- a/models/custom.py
+++ b/models/custom.py
@@ -320,21 +320,21 @@ class AHOY(nn.Module):
     @staticmethod
     def get_transform(imgsz, infsz):
         """Get the transformation to be applied to the image. Padding and/or resize, if needed."""
-        if imgsz != infsz:
-            pad_left, pad_right, pad_top, pad_bottom = AHOY.get_padding_for_aspect_ratio(imgsz, infsz)
-            ratio = max(imgsz[0] / infsz[0], imgsz[1] / infsz[1])
-            transform = transforms.Compose([])
-            if ratio != 1:
-                transform.transforms.extend(
-                    [transforms.Resize((infsz[0]-pad_top-pad_bottom, infsz[1]-pad_left-pad_right), interpolation=transforms.InterpolationMode.NEAREST, antialias=False)]
-                )
-            if pad_left != 0 or pad_right != 0 or pad_top != 0 or pad_bottom != 0:
-                transform.transforms.extend(
-                    [transforms.Pad(padding=(pad_left, pad_top, pad_right, pad_bottom), fill = 0, padding_mode="constant")]
-                )
-            return transform
-        else:
+        if imgsz == infsz:
             return None
+
+        pad_left, pad_right, pad_top, pad_bottom = AHOY.get_padding_for_aspect_ratio(imgsz, infsz)
+        ratio = max(imgsz[0] / infsz[0], imgsz[1] / infsz[1])
+        transform = transforms.Compose([])
+        if ratio != 1:
+            transform.transforms.extend(
+                [transforms.Resize((infsz[0]-pad_top-pad_bottom, infsz[1]-pad_left-pad_right), interpolation=transforms.InterpolationMode.NEAREST, antialias=False)]
+            )
+        if pad_left != 0 or pad_right != 0 or pad_top != 0 or pad_bottom != 0:
+            transform.transforms.extend(
+                [transforms.Pad(padding=(pad_left, pad_top, pad_right, pad_bottom), fill = 0, padding_mode="constant")]
+            )
+        return transform
 
     @staticmethod
     def get_padding_for_aspect_ratio(imgsz, infsz):

--- a/models/custom.py
+++ b/models/custom.py
@@ -268,6 +268,8 @@ class AHOY(nn.Module):
         device: Union[str, torch.device] = None,  # automatically select device
         fp16: bool = False,
         fuse: bool = True,  # fuse conv and bn layers
+        imgsz: list = [640,640],
+        infsz: list = [640,640],
         inplace: bool = True,  # inplace modification of models
     ):
         super().__init__()
@@ -277,17 +279,14 @@ class AHOY(nn.Module):
         self.fp16 = fp16
         self.stride = self.obj_det.stride
         self.names = self.obj_det.names
+        self.imgsz = imgsz
+        self.infsz = infsz
 
         # keep track of hooks
         self.hooks = {}
 
-        self.pad_left, self.pad_right, self.pad_top, self.pad_bottom = self.get_padding_for_aspect_ratio(1080, 3600, 640, 1280)
-        self.ratio = max(1080/640, 3600/1280)
-        print("PADS", self.pad_left, self.pad_right, self.pad_top, self.pad_bottom)
-        self.transform = transforms.Compose([
-            transforms.Resize((640-self.pad_top-self.pad_bottom, 1280-self.pad_left-self.pad_right), interpolation=transforms.InterpolationMode.NEAREST, antialias=False),
-            transforms.Pad(padding=(self.pad_left, self.pad_top, self.pad_right, self.pad_bottom), fill = 0, padding_mode="constant")
-        ])
+        # Scaling in Padding Preprocessing
+        self.transform = self.get_transform(imgsz, infsz)
 
     def forward(self, x, profile=False, visualize=False):
         """Forward pass through models."""
@@ -319,11 +318,33 @@ class AHOY(nn.Module):
         self.hooks.clear()
 
     @staticmethod
-    def get_padding_for_aspect_ratio(h_in, w_in, h_out, w_out):
+    def get_transform(imgsz, infsz):
+        """Get the transformation to be applied to the image. Padding and/or resize, if needed."""
+        if imgsz != infsz:
+            pad_left, pad_right, pad_top, pad_bottom = AHOY.get_padding_for_aspect_ratio(imgsz, infsz)
+            ratio = max(imgsz[0] / infsz[0], imgsz[1] / infsz[1])
+            transform = transforms.Compose([])
+            if ratio != 1:
+                transform.transforms.extend(
+                    [transforms.Resize((infsz[0]-pad_top-pad_bottom, infsz[1]-pad_left-pad_right), interpolation=transforms.InterpolationMode.NEAREST, antialias=False)]
+                )
+            if pad_left != 0 or pad_right != 0 or pad_top != 0 or pad_bottom != 0:
+                transform.transforms.extend(
+                    [transforms.Pad(padding=(pad_left, pad_top, pad_right, pad_bottom), fill = 0, padding_mode="constant")]
+                )
+            return transform
+        else:
+            return None
+
+    @staticmethod
+    def get_padding_for_aspect_ratio(imgsz, infsz):
         """
         Calculates padding (left, right, top, bottom) needed after resizing
         while preserving aspect ratio to fit exactly into (h_out, w_out).
         """
+        h_in, w_in = imgsz
+        h_out, w_out = infsz
+
         scale = min(h_out / h_in, w_out / w_in)
         new_h = int(h_in * scale)
         new_w = int(w_in * scale)
@@ -345,8 +366,9 @@ class AHOY(nn.Module):
         def _preprocess(x):
             if len(x.shape) <1 :
                 return x
-            x = x.float()
-            x = module.transform(x)
+            if module.transform is not None:
+                x = x.float()
+                x = module.transform(x)
             x = x.half() if module.fp16 else x.float()
             x = x / 255.0  # 0-255 to 0.0-1.0
             return x
@@ -362,12 +384,7 @@ class AHOY(nn.Module):
 
         # ahoy outputs: (tuple(Tensor, ...), Tensor, Tensor)
         first_tuple, second_item, third_item = outputs
-        # print(first_tuple[0].shape)
-        # print(first_tuple[0][0,0,:])
-        first_tuple[0][:,:,0] -= module.pad_left
-        first_tuple[0][:,:,1] -= module.pad_top
-        first_tuple[0][:,:,:4] *= module.ratio 
-        # print(first_tuple[0][0,0,:])
+
         # Only convert the first item of the first tuple (the detection outputs)
         first_tuple = (_to_float(first_tuple[0]),) + first_tuple[1:]
 


### PR DESCRIPTION
## What?
 
Add possibility to include preprocessing inside model's graph
 
## Why?
 
preprocessing in GPU is considerably faster (check values below)
 
## How?
 
by using torchivision tranforms and applying them only if necessery

## Backout plan

No backout plan should be necessery. For no preprocssing just be sure to export model with --imgsz equal to --infsz

## Testing

```
Average time - no preprocessing:  0.009861427148183187
Average time - gpu preprocessing:  0.010737588008244833
```
(CPU preprocessing takes more or less the same as the models forward pass)


![output](https://github.com/user-attachments/assets/848db753-40b5-46c9-b174-5c1b4ae3b5d7)

PS: did not include rescaling boxes back to original image input size inside graph but we can do it.


