### PR TITLE
`infsz` optional when exporting AHOY

### DIFF
--- a/export_ahoy.py
+++ b/export_ahoy.py
@@ -105,7 +105,7 @@ def main(
     det_weights: str,
     hor_weights: str,
     imgsz: int | Tuple[int, int],
-    infsz: int | Tuple[int, int],
+    infsz: int | Tuple[int, int] | None,
     batch_size: int,
     half: bool,
     fuse: bool,
@@ -115,7 +115,7 @@ def main(
     """Export the model to TensorRT engine."""
     # Transform image size to (height, width) format
     imgsz = _transform_sz(imgsz)
-    infsz = _transform_sz(infsz)
+    infsz = _transform_sz(imgsz) if infsz is None else _transform_sz(infsz)
     det_weights = get_weights_path(det_weights)
     hor_weights = get_weights_path(hor_weights)
 
@@ -168,7 +168,7 @@ def main(
 
 
 def _parse_args():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         "-dw",
         "--det-weights",
@@ -195,8 +195,8 @@ def _parse_args():
         "--infsz",
         nargs="+", 
         type=int, 
-        default=[640, 640], 
-        help="image shape during inference (h, w)"
+        default=None, 
+        help="image shape during inference (h, w). If not specified, uses same size as imgsz"
     )
     parser.add_argument(
         "-bs",

--- a/export_ahoy.py
+++ b/export_ahoy.py
@@ -77,20 +77,20 @@ def get_weights_path(weights_path: str) -> str:
     except Exception as e:
         logging.error(f"Failed to download from W&B: {str(e)}")
         raise e
-    
 
-def _transform_sz(imgsz: int | List[int] | Tuple[int,int]) -> Tuple[int,int]:
+
+def _transform_sz(imgsz: int | List[int] | Tuple[int, int]) -> Tuple[int, int]:
     """
     Convert size specifications to (height, width) tuple format.
-    
+
     Args:
         imgsz: Int, list, or tuple representing dimensions.
             - If int: converted to (imgsz, imgsz)
             - If list/tuple with 1 or 2 elements: converted to (imgsz[0], imgsz[-1])
-    
+
     Returns:
         Tuple in (height, width) format.
-        
+
     Raises:
         ValueError: If imgsz is not int, list, or tuple, or if list/tuple has more than 2 elements.
     """
@@ -100,6 +100,7 @@ def _transform_sz(imgsz: int | List[int] | Tuple[int,int]) -> Tuple[int,int]:
     if not isinstance(imgsz, (list, tuple)) or len(imgsz) not in (1, 2):
         raise ValueError(f"imgsz must be int or a list/tuple of 1 or 2 elements, got {imgsz}")
     return imgsz[0], imgsz[-1]
+
 
 def main(
     det_weights: str,
@@ -148,7 +149,7 @@ def main(
     model.register_io_hooks()  # inp: uint8 -> fp32/fp16 / 255.0, out: fp16 -> fp32
 
     # Create dummy input
-    image = torch.zeros((batch_size, 3, imgsz[0], imgsz[1]), device=model.device).byte() # B, C, H, W
+    image = torch.zeros((batch_size, 3, imgsz[0], imgsz[1]), device=model.device).byte()  # B, C, H, W
     # https://github.com/NVIDIA/TensorRT/issues/3026#issuecomment-1570419758
     image = image.float() if trt7_compatible else image
     print(f"🔮 Dummy input...{image.shape}, {image.dtype}")
@@ -183,20 +184,13 @@ def _parse_args():
         required=True,
         help="Path to the horizontal model weights.",
     )
-    parser.add_argument(
-        "-sz",
-        "--imgsz",
-        nargs="+", 
-        type=int, 
-        default=[640, 640], 
-        help="image input shape (h, w)"
-    )
+    parser.add_argument("-sz", "--imgsz", nargs="+", type=int, default=[640, 640], help="image input shape (h, w)")
     parser.add_argument(
         "--infsz",
-        nargs="+", 
-        type=int, 
-        default=None, 
-        help="image shape during inference (h, w). If not specified, uses same size as imgsz"
+        nargs="+",
+        type=int,
+        default=None,
+        help="image shape during inference (h, w). If not specified, uses same size as imgsz",
     )
     parser.add_argument(
         "-bs",


### PR DESCRIPTION
## What?
Makes `infsz` parameter optional by defaulting to `None`, which then uses the same size as `imgsz`.

## Why?
This change simplifies the API by making the inference size parameter optional, reducing the need for users to specify redundant parameters when they want the same size for both input and inference.

## How?
- Modified `infsz` parameter in `main()` to accept `None`
- Updated argument parser to set `infsz` default to `None`
- Added logic to use `imgsz` when `infsz` is `None`

## Backout plan
Simple revert of the changes since this is a non-breaking change that only affects default behavior. The original behavior can be restored by setting `infsz` explicitly.

## Testing
The changes can be tested with the following commands:

```bash
# Test default behavior (infsz = imgsz)
python export_ahoy.py --det-weights yolov5n.pt --hor-weights yolov11n-obb.pt --imgsz 640

# Test explicit infsz
python export_ahoy.py --det-weights yolov5n.pt --hor-weights yolov11n-obb.pt --imgsz 640 --infsz 320
```

Both commands should work as expected, with the first one using the same size for both parameters and the second one using different sizes.
