### PR TITLE
Improve exporting process for AHOY with OBB models

### DIFF
--- a/export.py
+++ b/export.py
@@ -331,15 +331,15 @@ def export_onnx(model, im, file, opset, dynamic, simplify, prefix=colorstr("ONNX
     check_requirements("onnx>=1.12.0")
     import onnx
 
-    from models.custom import AHOY, AHOYOBB, DAN
+    from models.custom import AHOY, AHOYv1, AHOYv2, DAN
 
     LOGGER.info(f"\n{prefix} starting export with onnx {onnx.__version__}...")
     f = str(file.with_suffix(".onnx"))
 
-    if isinstance(model,(SegmentationModel, AHOYOBB)):
+    if isinstance(model,(SegmentationModel, AHOYv2)):
         input_names = ["images"]
         output_names = ["output0", "output1"]
-    elif isinstance(model, AHOY):
+    elif isinstance(model, AHOYv1):
         input_names = ["images"]
         output_names = ["output0", "output1", "output2"]
     elif isinstance(model, DAN):

--- a/export_ahoy.py
+++ b/export_ahoy.py
@@ -144,7 +144,7 @@ def main(
     model(image)  # need to run once to get the model to JIT compile
 
     export_func = export_onnx_trt7_compatible if trt7_compatible else export_onnx
-    f, _ = export_func(
+    _ = export_func(
         model,
         im=image,
         file=Path(fname),
@@ -152,7 +152,6 @@ def main(
         simplify=False,
         opset=12,
     )
-    LOGGER.info(f"🎉 Model successfully exported to {f}! 🚀")
 
 
 def _parse_args():

--- a/export_ahoy.py
+++ b/export_ahoy.py
@@ -108,6 +108,7 @@ def main(
     half: bool,
     fuse: bool,
     dynamic: bool = False,
+    simplify: bool = False,
     trt7_compatible: bool = False,
     fname: str = "",
 ):
@@ -149,7 +150,7 @@ def main(
         im=image,
         file=Path(fname),
         dynamic=dynamic,
-        simplify=False,
+        simplify=simplify,
         opset=12,
     )
 
@@ -196,6 +197,12 @@ def _parse_args():
         "--half",
         action="store_true",
         help="Export half-precision model.",
+    )
+    parser.add_argument(
+        "-si",
+        "--simplify",
+        action="store_true",
+        help="Simplify the exported model.",
     )
     parser.add_argument(
         "-trt7",

--- a/export_ahoy.py
+++ b/export_ahoy.py
@@ -34,7 +34,6 @@ NOTE: For TensorRT 7 compatible models, use the --trt7-compatible flag.
 """
 
 import argparse
-import logging
 from pathlib import Path
 from typing import List, Tuple
 
@@ -43,8 +42,8 @@ import torch
 from export import export_onnx, export_onnx_trt7_compatible
 from models.custom import AHOY, AHOYOBB
 from models.yolo import Detect
+from utils.general import LOGGER
 
-logging.basicConfig(level=logging.INFO)
 
 
 def get_weights_path(weights_path: str) -> str:
@@ -62,7 +61,7 @@ def get_weights_path(weights_path: str) -> str:
     try:
         import wandb
     except ImportError:
-        logging.error("Please install wandb to download models from W&B registry")
+        LOGGER.error("Please install wandb to download models from W&B registry")
         return weights_path
 
     try:
@@ -75,7 +74,7 @@ def get_weights_path(weights_path: str) -> str:
         return next(Path(artifact_path).glob("*.pt"))
 
     except Exception as e:
-        logging.error(f"Failed to download from W&B: {str(e)}")
+        LOGGER.error(f"Failed to download from W&B: {str(e)}")
         raise e
 
 
@@ -133,14 +132,14 @@ def main(
     if not fname:
         input_size = f"{imgsz[0]}x{imgsz[1]}"
         fname = f"{type(model).__name__.lower()}_b{batch_size}_sz{input_size}.onnx"
-    print(f"🚀 Exporting model {type(model).__name__} to {fname}...")
+    LOGGER.info(f"🚀 Exporting model {type(model).__name__} to {fname}...")
 
     inplace = False  # default
     dynamic = False  # default
 
     # Update model
     model.eval()
-    print("✨ Preparing the model for export...")
+    LOGGER.info("✨ Preparing the model for export...")
     for _, m in model.named_modules():
         if isinstance(m, Detect):
             m.inplace = inplace
@@ -152,7 +151,7 @@ def main(
     image = torch.zeros((batch_size, 3, imgsz[0], imgsz[1]), device=model.device).byte()  # B, C, H, W
     # https://github.com/NVIDIA/TensorRT/issues/3026#issuecomment-1570419758
     image = image.float() if trt7_compatible else image
-    print(f"🔮 Dummy input...{image.shape}, {image.dtype}")
+    LOGGER.info(f"🔮 Dummy input...{image.shape}, {image.dtype}")
 
     model(image)  # need to run once to get the model to JIT compile
 
@@ -165,7 +164,7 @@ def main(
         simplify=False,
         opset=12,
     )
-    print(f"🎉 Model successfully exported to {f}! 🚀")
+    LOGGER.info(f"🎉 Model successfully exported to {f}! 🚀")
 
 
 def _parse_args():

--- a/export_ahoy.py
+++ b/export_ahoy.py
@@ -1,5 +1,5 @@
 """
-Export AHOY or AHOYOBB(with Horizon-OBB) to ONNX format.
+Export AHOY to ONNX format.
 
 ONNX is an open standard for machine learning models that enables interoperability 
 between different frameworks and platforms.
@@ -40,8 +40,7 @@ from typing import List, Tuple
 import torch
 
 from export import export_onnx, export_onnx_trt7_compatible
-from models.custom import AHOY, AHOYOBB
-from models.yolo import Detect
+from models.custom import AHOY
 from utils.general import LOGGER
 
 
@@ -70,7 +69,7 @@ def get_weights_path(weights_path: str) -> str:
         api = wandb.Api()
         artifact_name = f"wandb-registry-{REGISTRY}/{collection}:{version}"
         artifact_path = api.artifact(name=artifact_name).download(root=Path("artifacts", weights_path))
-        return next(Path(artifact_path).glob("*.pt"))
+        return str(next(Path(artifact_path).glob("*.pt")))
 
     except Exception as e:
         LOGGER.error(f"Failed to download from W&B: {str(e)}")
@@ -119,8 +118,7 @@ def main(
     det_weights = get_weights_path(det_weights)
     hor_weights = get_weights_path(hor_weights)
 
-    model_class = AHOYOBB if "obb" in str(hor_weights).lower() else AHOY
-    model = model_class(
+    model = AHOY(
         obj_det_weigths=det_weights,
         hor_det_weights=hor_weights,
         fp16=half,

--- a/export_ahoy.py
+++ b/export_ahoy.py
@@ -45,7 +45,6 @@ from models.yolo import Detect
 from utils.general import LOGGER
 
 
-
 def get_weights_path(weights_path: str) -> str:
     """Get model weights from local path or W&B registry.
 
@@ -109,6 +108,7 @@ def main(
     batch_size: int,
     half: bool,
     fuse: bool,
+    dynamic: bool = False,
     trt7_compatible: bool = False,
     fname: str = "",
 ):
@@ -134,17 +134,7 @@ def main(
         fname = f"{type(model).__name__.lower()}_b{batch_size}_sz{input_size}.onnx"
     LOGGER.info(f"🚀 Exporting model {type(model).__name__} to {fname}...")
 
-    inplace = False  # default
-    dynamic = False  # default
-
-    # Update model
-    model.eval()
-    LOGGER.info("✨ Preparing the model for export...")
-    for _, m in model.named_modules():
-        if isinstance(m, Detect):
-            m.inplace = inplace
-            m.dynamic = dynamic
-            m.export = True
+    model.prepare_for_export(dynamic=dynamic)
     model.register_io_hooks()  # inp: uint8 -> fp32/fp16 / 255.0, out: fp16 -> fp32
 
     # Create dummy input

--- a/export_ahoy.py
+++ b/export_ahoy.py
@@ -71,7 +71,7 @@ def get_weights_path(weights_path: str) -> str:
 
         api = wandb.Api()
         artifact_name = f"wandb-registry-{REGISTRY}/{collection}:{version}"
-        artifact_path = api.artifact(name=artifact_name).download()
+        artifact_path = api.artifact(name=artifact_name).download(root=Path("artifacts", weights_path))
         return next(Path(artifact_path).glob("*.pt"))
 
     except Exception as e:
@@ -120,7 +120,7 @@ def main(
     det_weights = get_weights_path(det_weights)
     hor_weights = get_weights_path(hor_weights)
 
-    model_class = AHOYOBB if "obb" in hor_weights.lower() else AHOY
+    model_class = AHOYOBB if "obb" in str(hor_weights).lower() else AHOY
     model = model_class(
         obj_det_weigths=det_weights,
         hor_det_weights=hor_weights,

--- a/models/custom.py
+++ b/models/custom.py
@@ -347,7 +347,29 @@ class ObjectsModel(BaseModel):
 
 
 class AHOY(nn.Module):
-    """A H-orizon O-bject detection Y-OLOv5."""
+    """Base class for AHOY models.
+
+    AHOY Stands for the following:
+    - **A**
+    - **H**orizon and
+    - **O**bject detection
+    - **Y**olo-based model
+    """
+
+    def __new__(cls, hor_det_weights: str, **kwargs):
+        """Create the appropriate AHOY model instance based on the model path.
+
+        Args:
+            model_path: Path to the model file.
+            device: CUDA device to use.
+            **kwargs: Additional arguments passed to the constructor.
+
+        Returns:
+            An instance of either AHOYv1 or AHOYv2 based on the model path.
+        """
+        if any(x in hor_det_weights.lower() for x in ("obb")):
+            return super().__new__(AHOYv2)
+        return super().__new__(AHOYv1)
 
     # Ensemble of models
     def __init__(
@@ -399,13 +421,11 @@ class AHOY(nn.Module):
         self, hor_det_weights: str, device: Union[str, torch.device] = None, fp16: bool = False, fuse: bool = True
     ):
         """Load horizon detection model."""
-        return HorizonModel(hor_det_weights, device=device, fp16=fp16, fuse=fuse)
+        raise NotImplementedError("Subclasses should implement this method")
 
     def forward(self, x, profile=False, visualize=False):
         """Forward pass through models."""
-        objects = self.obj_det(x, profile, visualize)
-        pitch, theta = self.hor_det(x, profile, visualize)
-        return objects, pitch, theta
+        raise NotImplementedError("Subclasses should implement this method")
 
     def register_preprocessing_hook(self):
         """Register hooks to convert uint8 to fp16/fp32 and scale by 1/255 before forward pass."""
@@ -506,6 +526,34 @@ class AHOY(nn.Module):
     @staticmethod
     def _postprocessing_hook(module, inputs, outputs):
         """Convert outputs to float (if needed) and apply softmax to logits."""
+        raise NotImplementedError("Subclasses should implement this method")
+
+    def prepare_for_export(self, dynamic: bool = False):
+        """Prepare model for export."""
+        LOGGER.info(f"✨ Preparing {self.obj_det.__class__.__name__} for export...")
+        self.obj_det.prepare_for_export(dynamic)
+        LOGGER.info(f"✨ Preparing {self.hor_det.__class__.__name__} for export...")
+        self.hor_det.prepare_for_export(dynamic)
+
+
+class AHOYv1(AHOY):
+    """A H-orizon O-bject detection Y-OLOv5 (object detection with yolov5)."""
+
+    def load_hor_det(
+        self, hor_det_weights: str, device: Union[str, torch.device] = None, fp16: bool = False, fuse: bool = True
+    ):
+        """Load horizon detection model."""
+        return HorizonModel(hor_det_weights, device=device, fp16=fp16, fuse=fuse)
+
+    def forward(self, x, profile=False, visualize=False):
+        """Forward pass through models."""
+        objects = self.obj_det(x, profile, visualize)
+        pitch, theta = self.hor_det(x, profile, visualize)
+        return objects, pitch, theta
+
+    @staticmethod
+    def _postprocessing_hook(module, inputs, outputs):
+        """Convert outputs to float (if needed) and apply softmax to logits."""
 
         def _to_float(x):
             return x.float() if module.fp16 else x
@@ -523,16 +571,9 @@ class AHOY(nn.Module):
         # Reconstruct the overall output
         return (first_tuple, _to_float(second_item), _to_float(third_item))
 
-    def prepare_for_export(self, dynamic: bool = False):
-        """Prepare model for export."""
-        LOGGER.info(f"✨ Preparing {self.obj_det.__class__.__name__} for export...")
-        self.obj_det.prepare_for_export(dynamic)
-        LOGGER.info(f"✨ Preparing {self.hor_det.__class__.__name__} for export...")
-        self.hor_det.prepare_for_export(dynamic)
 
-
-class AHOYOBB(AHOY):
-    """A H-orizon (with OBB) O-bject detection Y-OLOv5 (object detection with yolov5)."""
+class AHOYv2(AHOY):
+    """A H-orizon O-bject detection Y-OLOv5 (object detection with yolov5)."""
 
     def load_hor_det(
         self, hor_det_weights: str, device: Union[str, torch.device] = None, fp16: bool = False, fuse: bool = True
@@ -669,7 +710,10 @@ class Hydra(BaseModel):
 
         self.model = model.model
         self.model.to(self.device)
-        self.model.half() if fp16 else self.model.float()
+        if self.fp16:
+            self.model.half()
+        else:
+            self.model.float()
         self.save = model.save
         self.stride = model.stride
         self.nc = model.nc
@@ -742,13 +786,12 @@ class Hydra(BaseModel):
 
         return (x, x_pitch, x_theta)
 
-    def forward(self, x):
+    def forward(self, x, profile=False, visualize=False):
         if self.task == "detection":
-            return self._detect_once(x)
-        elif self.task == "horizon":
-            return self._horizon_once(x)
-        else:
-            return self._forward_once(x)
+            return self._detect_once(x, profile, visualize)
+        if self.task == "horizon":
+            return self._horizon_once(x, profile, visualize)
+        return self._forward_once(x, profile, visualize)
 
 
 def _find_cutoff(model):

--- a/models/custom.py
+++ b/models/custom.py
@@ -1,21 +1,23 @@
 from pathlib import Path
-from typing import Union
+from typing import Union, Tuple, Optional
 
 import numpy as np
 import torch
 from torch import nn
 from torchvision import transforms
-from ultralytics import YOLO
 
-from models.common import Classify, DetectMultiBackend
-from models.experimental import attempt_load
-from models.yolo import BaseModel, DetectionModel
+from ultralytics import YOLO
+from ultralytics.nn.tasks import BaseModel as UBaseModel
+
 from utils.general import LOGGER
 from utils.plots import feature_visualization
 from utils.torch_utils import select_device
+from models.common import Classify, DetectMultiBackend
+from models.experimental import attempt_load
+from models.yolo import BaseModel, DetectionModel, Detect
 
 
-class OBBModel(BaseModel):
+class OBBModel(UBaseModel):
     """Wrapper around yolo-OBB Model."""
 
     def __init__(
@@ -31,19 +33,49 @@ class OBBModel(BaseModel):
 
         if Path(weights).is_file() or weights.endswith(".pt"):
             model = YOLO(model=weights)
-            if fuse:
-                model.fuse()
-            model = model.model
-            stride = model.stride
             LOGGER.info(f"Loaded weights from {weights}")
         else:
             raise ValueError("model must be a path to a .pt file")
 
-        self.model = model.model
-        self.model.to(self.device)
-        self.model.half() if fp16 else self.model.float()
-        self.stride = stride
-        self.save = model.save
+        model.to(self.device)
+        if fuse:
+            model.fuse()
+        if fp16:
+            model.half()
+        else:
+            model.float()
+        self.names = model.names
+        self.stride = model.model.stride
+        self.save = model.model.save
+        self.model = model.model.model  # YOLO.OBBModel.Sequential
+
+    def prepare_for_export(self, dynamic: bool = False):
+        """Prepare model for export."""
+        from ultralytics.nn import modules  # import C2f, Classify, Detect, RTDETRDecoder
+
+        for p in self.model.parameters():
+            p.requires_grad = False
+        self.model.eval()
+
+        for m in self.model.modules():
+            if isinstance(m, modules.Classify):
+                m.export = True
+            if isinstance(
+                m, (modules.Detect, modules.RTDETRDecoder)
+            ):  # includes all Detect subclasses like Segment, Pose, OBB
+                m.dynamic = dynamic
+                m.export = True
+                m.format = "onnx"
+                m.max_det = 1000
+                m.xyxy = True  # self.args.nms and not coreml
+            elif isinstance(m, modules.C2f):
+                # EdgeTPU does not support FlexSplitV while split provides cleaner ONNX graph
+                m.forward = m.forward_split
+
+    def init_criterion(self):
+        """Initialize the loss criterion for the BaseModel."""
+        raise NotImplementedError("compute_loss() needs to be implemented by task heads")
+
 
 class HorizonModel(BaseModel):
     """YOLOv5 backbone + classification heads for pitch and theta."""
@@ -95,8 +127,10 @@ class HorizonModel(BaseModel):
 
         self.model = model.model
         self.model.to(self.device)
-      
-        self.model.half() if fp16 else self.model.float()
+        if fp16:
+            self.model.half()
+        else:
+            self.model.float()
         self.stride = stride
         self.save = model.save
 
@@ -256,6 +290,17 @@ class HorizonModel(BaseModel):
 
         return (mu_pitch, amp_pitch, sigma_pitch), (mu_theta, amp_theta, sigma_theta)
 
+    def prepare_for_export(self, dynamic: bool = False):
+        """Prepare model for export."""
+        self.model.eval()
+
+        # Update model
+        for _, m in self.model.named_modules():
+            if isinstance(m, Detect):
+                m.inplace = False
+                m.dynamic = dynamic
+                m.export = True
+
 
 class ObjectsModel(BaseModel):
     """Wrapper around YOLOv5 DetectionModel."""
@@ -281,11 +326,24 @@ class ObjectsModel(BaseModel):
 
         self.model = model.model
         self.model.to(self.device)
-        self.model.half() if fp16 else self.model.float()
+        if fp16:
+            self.model.half()
+        else:
+            self.model.float()
         self.stride = stride
         self.names = names
         self.save = model.save
 
+    def prepare_for_export(self, dynamic: bool = False):
+        """Prepare model for export."""
+        self.model.eval()
+
+        # Update model
+        for _, m in self.model.named_modules():
+            if isinstance(m, Detect):
+                m.inplace = False
+                m.dynamic = dynamic
+                m.export = True
 
 
 class AHOY(nn.Module):
@@ -299,25 +357,49 @@ class AHOY(nn.Module):
         device: Union[str, torch.device] = None,  # automatically select device
         fp16: bool = False,
         fuse: bool = True,  # fuse conv and bn layers
-        imgsz: list = [640,640],
-        infsz: list = [640,640],
-        inplace: bool = True,  # inplace modification of models
+        imgsz: Tuple[int, int] = (640, 640),
+        infsz: Optional[Tuple[int, int]] = None,
     ):
         super().__init__()
-        self.obj_det = ObjectsModel(obj_det_weigths, device=device, fp16=fp16, fuse=fuse)
-        self.hor_det = HorizonModel(hor_det_weights, device=device, fp16=fp16, fuse=fuse)
-        self.device = select_device(device)
+        self.obj_det = self.load_obj_det(obj_det_weigths, device=device, fp16=fp16, fuse=fuse)
+        self.hor_det = self.load_hor_det(hor_det_weights, device=device, fp16=fp16, fuse=fuse)
+        self.device = self.obj_det.device
         self.fp16 = fp16
         self.stride = self.obj_det.stride
         self.names = self.obj_det.names
         self.imgsz = imgsz
-        self.infsz = infsz
+        self.infsz = infsz if infsz is not None else imgsz
 
         # keep track of hooks
         self.hooks = {}
 
         # Scaling in Padding Preprocessing
         self.transform = self.get_transform(imgsz, infsz)
+
+        LOGGER.debug(
+            f"Object detection model info: "
+            f"model.type={type(self.obj_det.model).__name__}, "
+            f"save={self.obj_det.save}, "
+            f"stride={self.obj_det.stride}"
+        )
+        LOGGER.debug(
+            f"Horizon detection model info: "
+            f"model.type={type(self.hor_det.model).__name__}, "
+            f"save={self.hor_det.save}, "
+            f"stride={self.hor_det.stride}"
+        )
+
+    def load_obj_det(
+        self, obj_det_weigths: str, device: Union[str, torch.device] = None, fp16: bool = False, fuse: bool = True
+    ):
+        """Load object detection model."""
+        return ObjectsModel(obj_det_weigths, device=device, fp16=fp16, fuse=fuse)
+
+    def load_hor_det(
+        self, hor_det_weights: str, device: Union[str, torch.device] = None, fp16: bool = False, fuse: bool = True
+    ):
+        """Load horizon detection model."""
+        return HorizonModel(hor_det_weights, device=device, fp16=fp16, fuse=fuse)
 
     def forward(self, x, profile=False, visualize=False):
         """Forward pass through models."""
@@ -349,9 +431,9 @@ class AHOY(nn.Module):
         self.hooks.clear()
 
     @staticmethod
-    def get_transform(imgsz, infsz):
+    def get_transform(imgsz: Tuple[int, int], infsz: Optional[Tuple[int, int]] = None):
         """Get the transformation to be applied to the image. Padding and/or resize, if needed."""
-        if imgsz == infsz:
+        if imgsz == infsz or infsz is None:
             return None
 
         pad_left, pad_right, pad_top, pad_bottom = AHOY.get_padding_for_aspect_ratio(imgsz, infsz)
@@ -359,11 +441,26 @@ class AHOY(nn.Module):
         transform = transforms.Compose([])
         if ratio != 1:
             transform.transforms.extend(
-                [transforms.Resize((infsz[0]-pad_top-pad_bottom, infsz[1]-pad_left-pad_right), interpolation=transforms.InterpolationMode.NEAREST, antialias=False)]
+                [
+                    transforms.Resize(
+                        (
+                            infsz[0] - pad_top - pad_bottom,
+                            infsz[1] - pad_left - pad_right,
+                        ),
+                        interpolation=transforms.InterpolationMode.NEAREST,
+                        antialias=False,
+                    )
+                ]
             )
         if pad_left != 0 or pad_right != 0 or pad_top != 0 or pad_bottom != 0:
             transform.transforms.extend(
-                [transforms.Pad(padding=(pad_left, pad_top, pad_right, pad_bottom), fill = 0, padding_mode="constant")]
+                [
+                    transforms.Pad(
+                        padding=(pad_left, pad_top, pad_right, pad_bottom),
+                        fill=0,
+                        padding_mode="constant",
+                    )
+                ]
             )
         return transform
 
@@ -395,7 +492,7 @@ class AHOY(nn.Module):
         """Add preprocessing operations to be part of the model."""
 
         def _preprocess(x):
-            if len(x.shape) <1 :
+            if len(x.shape) < 1:
                 return x
             if module.transform is not None:
                 x = x.float()
@@ -426,38 +523,22 @@ class AHOY(nn.Module):
         # Reconstruct the overall output
         return (first_tuple, _to_float(second_item), _to_float(third_item))
 
+    def prepare_for_export(self, dynamic: bool = False):
+        """Prepare model for export."""
+        LOGGER.info(f"✨ Preparing {self.obj_det.__class__.__name__} for export...")
+        self.obj_det.prepare_for_export(dynamic)
+        LOGGER.info(f"✨ Preparing {self.hor_det.__class__.__name__} for export...")
+        self.hor_det.prepare_for_export(dynamic)
+
 
 class AHOYOBB(AHOY):
     """A H-orizon (with OBB) O-bject detection Y-OLOv5 (object detection with yolov5)."""
 
-    # Ensemble of models
-    def __init__(
-        self,
-        obj_det_weigths: str,
-        hor_det_weights: str,
-        device: Union[str,
-                    torch.device] = None,  # automatically select device
-        fp16: bool = False,
-        fuse: bool = True,  # fuse conv and bn layers
-        imgsz: list = [640, 640],
-        infsz: list = [640, 640],
-        inplace: bool = True,  # inplace modification of models
+    def load_hor_det(
+        self, hor_det_weights: str, device: Union[str, torch.device] = None, fp16: bool = False, fuse: bool = True
     ):
-        nn.Module.__init__(self) 
-        self.obj_det = ObjectsModel(obj_det_weigths, device=device, fp16=fp16, fuse=fuse)
-        self.hor_det = OBBModel(hor_det_weights, device=device, fp16=fp16, fuse=fuse)
-        self.device = select_device(device)
-        self.fp16 = fp16
-        self.stride = self.obj_det.stride
-        self.names = self.obj_det.names
-        self.imgsz = imgsz
-        self.infsz = infsz
-
-        # keep track of hooks
-        self.hooks = {}
-        print("🚀 AHOY model: yolov5 + yolo[v8|11]-obb")
-        # Scaling in Padding Preprocessing
-        self.transform = self.get_transform(imgsz, infsz)
+        """Load horizon detection model."""
+        return OBBModel(hor_det_weights, device=device, fp16=fp16, fuse=fuse)
 
     def forward(self, x, profile=False, visualize=False):
         """Forward pass through models."""
@@ -472,14 +553,16 @@ class AHOYOBB(AHOY):
         def _to_float(x):
             return x.float() if module.fp16 else x
 
-        # ahoy outputs: (tuple(Tensor, ...), Tensor, Tensor)
-        first_tuple, second_tuple = outputs
+        # first_tuple: (tuple(Tensor, ...), Tensor)
+        # second_tuple: Tensor
+        first_tuple, second_item = outputs
 
         # Only convert the first item of the first tuple (the detection outputs)
-        first_tuple = (_to_float(first_tuple[0]), ) + first_tuple[1:]
-        second_tuple = (_to_float(second_tuple[0].transpose(1, 2)), ) 
+        first_tuple = (_to_float(first_tuple[0]),) + first_tuple[1:]
+        second_item = _to_float(second_item.transpose(1, 2))
 
-        return (first_tuple, second_tuple)
+        return (first_tuple, second_item)
+
 
 class DAN(nn.Module):
     """

--- a/models/custom.py
+++ b/models/custom.py
@@ -9,7 +9,7 @@ from torchvision import transforms
 from ultralytics import YOLO
 from ultralytics.nn.tasks import BaseModel as UBaseModel
 
-from utils.general import LOGGER
+from utils.general import LOGGER, scale_boxes
 from utils.plots import feature_visualization
 from utils.torch_utils import select_device
 from models.common import Classify, DetectMultiBackend
@@ -396,7 +396,7 @@ class AHOY(nn.Module):
         self.hooks = {}
 
         # Scaling in Padding Preprocessing
-        self.transform = self.get_transform(imgsz, infsz)
+        self.transform, self.ratio_pad = self.get_transform(imgsz, infsz)
 
         LOGGER.debug(
             f"Object detection model info: "
@@ -454,10 +454,11 @@ class AHOY(nn.Module):
     def get_transform(imgsz: Tuple[int, int], infsz: Optional[Tuple[int, int]] = None):
         """Get the transformation to be applied to the image. Padding and/or resize, if needed."""
         if imgsz == infsz or infsz is None:
-            return None
+            return None, None
 
         pad_left, pad_right, pad_top, pad_bottom = AHOY.get_padding_for_aspect_ratio(imgsz, infsz)
         ratio = max(imgsz[0] / infsz[0], imgsz[1] / infsz[1])
+        ratio_pad = [[1 / ratio], [pad_left, pad_top]]  # [[gain], [pad_x, pad_y]] for scale_boxes
         transform = transforms.Compose([])
         if ratio != 1:
             transform.transforms.extend(
@@ -467,7 +468,7 @@ class AHOY(nn.Module):
                             infsz[0] - pad_top - pad_bottom,
                             infsz[1] - pad_left - pad_right,
                         ),
-                        interpolation=transforms.InterpolationMode.NEAREST,
+                        interpolation=transforms.InterpolationMode.BILINEAR,
                         antialias=False,
                     )
                 ]
@@ -482,7 +483,7 @@ class AHOY(nn.Module):
                     )
                 ]
             )
-        return transform
+        return transform, ratio_pad
 
     @staticmethod
     def get_padding_for_aspect_ratio(imgsz, infsz):
@@ -561,6 +562,12 @@ class AHOYv1(AHOY):
         # ahoy outputs: (tuple(Tensor, ...), Tensor, Tensor)
         first_tuple, second_item, third_item = outputs
 
+        # Scale back boxes if transform was applied
+        if module.ratio_pad is not None:
+            first_tuple = (
+                scale_boxes(module.infsz, first_tuple[0], module.imgsz, ratio_pad=module.ratio_pad),
+            ) + first_tuple[1:]
+
         # Only convert the first item of the first tuple (the detection outputs)
         first_tuple = (_to_float(first_tuple[0]),) + first_tuple[1:]
 
@@ -598,9 +605,21 @@ class AHOYv2(AHOY):
         # second_tuple: Tensor
         first_tuple, second_item = outputs
 
+        # transpose to (batch_size, num_boxes, num_classes)
+        second_item = second_item.transpose(1, 2)
+
+        # Scale back boxes if transform was applied
+        if module.ratio_pad is not None:
+            first_tuple = (
+                scale_boxes(module.infsz, first_tuple[0], module.imgsz, ratio_pad=module.ratio_pad),
+            ) + first_tuple[1:]
+            second_item = scale_boxes(
+                module.infsz, second_item, module.imgsz, ratio_pad=module.ratio_pad, xywh=True, clip=False
+            )
+
         # Only convert the first item of the first tuple (the detection outputs)
         first_tuple = (_to_float(first_tuple[0]),) + first_tuple[1:]
-        second_item = _to_float(second_item.transpose(1, 2))
+        second_item = _to_float(second_item)
 
         return (first_tuple, second_item)
 

--- a/utils/general.py
+++ b/utils/general.py
@@ -959,11 +959,15 @@ def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None, xywh: bool = Fals
         gain = ratio_pad[0][0]
         pad = ratio_pad[1]
 
-    boxes[..., 0] -= pad[0]  # x padding
-    boxes[..., 1] -= pad[1]  # y padding
+    if pad[0] != 0:
+        boxes[..., 0] -= pad[0]  # x padding
+    if pad[1] != 0:
+        boxes[..., 1] -= pad[1]  # y padding
     if not xywh:
-        boxes[..., 2] -= pad[0]  # x padding
-        boxes[..., 3] -= pad[1]  # y padding
+        if pad[0] != 0:
+            boxes[..., 2] -= pad[0]  # x padding
+        if pad[1] != 0:
+            boxes[..., 3] -= pad[1]  # y padding
     boxes[..., :4] /= gain
     if clip:
         clip_boxes(boxes, img0_shape)

--- a/utils/general.py
+++ b/utils/general.py
@@ -950,7 +950,7 @@ def resample_segments(segments, n=1000):
     return segments
 
 
-def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None):
+def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None, xywh: bool = False, clip: bool = True):
     """Rescales (xyxy) bounding boxes from img1_shape to img0_shape, optionally using provided `ratio_pad`."""
     if ratio_pad is None:  # calculate from img0_shape
         gain = min(img1_shape[0] / img0_shape[0], img1_shape[1] / img0_shape[1])  # gain  = old / new
@@ -959,10 +959,14 @@ def scale_boxes(img1_shape, boxes, img0_shape, ratio_pad=None):
         gain = ratio_pad[0][0]
         pad = ratio_pad[1]
 
-    boxes[..., [0, 2]] -= pad[0]  # x padding
-    boxes[..., [1, 3]] -= pad[1]  # y padding
+    boxes[..., 0] -= pad[0]  # x padding
+    boxes[..., 1] -= pad[1]  # y padding
+    if not xywh:
+        boxes[..., 2] -= pad[0]  # x padding
+        boxes[..., 3] -= pad[1]  # y padding
     boxes[..., :4] /= gain
-    clip_boxes(boxes, img0_shape)
+    if clip:
+        clip_boxes(boxes, img0_shape)
     return boxes
 
 


### PR DESCRIPTION
## What?

Refactored the model export process to ensure the **ONNX graph retains all [simplifications](https://github.com/SEA-AI/ultralytics/blob/1bbea68fb43d342298a5c30d0d5f7597da868002/ultralytics/engine/exporter.py#L413-L445) implemented in the original ultralytics repository**.

Also, new naming convention:
-`AHOY` --> `AHOYv1` 
-`AHOYOBB` --> `AHOYv2`

![saiyan2evolcution](https://media.tenor.com/8cLsBWWSGHEAAAAM/goku-ssj2.gif)

> [!TIP]
> You can still use `AHOY(obj_det_weigths="", hor_det_weigths="", ...)`; the correct version will be selected automatically based on the provided weights 🤞  

## Why?

Addressed these key issues in the export pipeline:

1. Residual gradient outputs: the OBBModel was still producing gradient tensors (ignored via post-processing hook).
2. Model-specific pre-export steps: both YOLOv8 and YOLO11 require their own sequence of tensor adjustments before export which are a bit different from YOLOv5.
3. Architectural insights mixed with naming.

> [!NOTE]
> There is nothing *wrong* with `AHOYOBB`, but… what if in the future we do both object and horizon detection with OBB models? Would we call it `AHOYOBBOBB` or `AHOYOBB²`?
>
> A more conventional naming scheme (a.k.a. `AHOYv*`) could help keep architectural insights and naming separate. You don’t see names like `YOLOAnchorless` or `YOLOFlashAttention`, those details are captured in documentation or model cards, not embedded in the name. Following that spirit keeps names clean and evolution-friendly.

## How

1. Switched from `logging` to `LOGGER` for unified logging
2. Added `prepare_for_export()` to centralize export logic in model classes
4. Create an `AHOY` base class and subclasses for `AHOYv1` and `AHOYv2`.

## Backout plan

The changes improve the exporting, they should not be reverted.
 
## Testing

### W&B integration

```console
$ python3 export_ahoy.py -dw YOLOv5n6-MIX:latest -hw YOLO11n-OBBh:latest -sz 576 1920 -bs 1 --half --fuse -f /Users/kevinserrano/Downloads/ahoy-obb-MIX-576x1920.onnx
🚀 SEA.AI custom version
wandb:   1 of 1 files downloaded.  
wandb:   1 of 1 files downloaded.  
YOLOv5 🚀 v7.0-496-g0c1db812 Python-3.12.8 torch-2.5.1 CPU

Fusing layers... 
Model summary: 206 layers, 3104644 parameters, 0 gradients, 4.3 GFLOPs
Loaded weights from artifacts/YOLOv5n6-MIX:latest/best.pt
YOLOv5 🚀 v7.0-496-g0c1db812 Python-3.12.8 torch-2.5.1 CPU

Loaded weights from artifacts/YOLO11n-OBBh:latest/best.pt
YOLO11n-obb summary (fused): 109 layers, 2,653,918 parameters, 0 gradients, 6.6 GFLOPs
🚀 Exporting model AHOYv2 to /Users/kevinserrano/Downloads/ahoy-obb-MIX-576x1920.onnx...
✨ Preparing ObjectsModel for export...
✨ Preparing OBBModel for export...
🔮 Dummy input...torch.Size([1, 3, 576, 1920]), torch.uint8

ONNX: starting export with onnx 1.17.0...
...
ONNX: export success ✅ 7.0s, saved as /Users/kevinserrano/Downloads/ahoy-obb-MIX-576x1920.onnx (11.8 MB)
🎉 Model successfully exported to /Users/kevinserrano/Downloads/ahoy-obb-MIX-576x1920.onnx! 🚀
```

### Before
 
<img width="535" alt="image" src="https://github.com/user-attachments/assets/1a40d326-a69b-4977-9718-09106fbfb847" />

### After

<img width="535" alt="image" src="https://github.com/user-attachments/assets/8a32a5a2-671f-43b7-8a03-8c1c60e0dfa5" />
