### PR TITLE
add metadata to onnx export

### DIFF
--- a/export.py
+++ b/export.py
@@ -60,6 +60,8 @@ import pandas as pd
 import torch
 from torch.utils.mobile_optimizer import optimize_for_mobile
 
+from utils.torch_utils import get_resize_info
+
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # YOLOv5 root directory
 if str(ROOT) not in sys.path:
@@ -380,17 +382,23 @@ def export_onnx(model, im, file, opset, dynamic, simplify, prefix=colorstr("ONNX
 
     # Metadata
     if isinstance(model, DAN):
+
+        resize_info = [get_resize_info(model.model_a), get_resize_info(model_or_transform=model.model_b)]
+
         d = {
             "stride": [int(max(model.model_a.stride)), int(max(model.model_b.stride))],
             "names": [model.model_a.names, model.model_b.names],
-            "inference-size": [model.model_a.infsz, model.model_b.infsz],
-            "image-size": [model.model_a.imgsz, model.model_b.imgsz]
+            "resize": resize_info if any(resize_info) else None
+
         }
+        
     else:
-        d = {"stride": int(max(model.stride)), 
-             "names": model.names,
-             "inference-size": getattr(model, "infsz", None),
-             "image-size": getattr(model, "imgsz", None)}
+        
+        d = {
+            "stride": int(max(model.stride)),
+            "names": model.names,
+            "resize": get_resize_info(model)
+        }
         
     for k, v in {k: v for k, v in d.items() if v}.items():
         meta = model_onnx.metadata_props.add()

--- a/export.py
+++ b/export.py
@@ -331,7 +331,7 @@ def export_onnx(model, im, file, opset, dynamic, simplify, prefix=colorstr("ONNX
     check_requirements("onnx>=1.12.0")
     import onnx
 
-    from models.custom import AHOY, AHOYv1, AHOYv2, DAN
+    from models.custom import AHOY, DAN, AHOYv1, AHOYv2
 
     LOGGER.info(f"\n{prefix} starting export with onnx {onnx.__version__}...")
     f = str(file.with_suffix(".onnx"))
@@ -383,12 +383,19 @@ def export_onnx(model, im, file, opset, dynamic, simplify, prefix=colorstr("ONNX
         d = {
             "stride": [int(max(model.model_a.stride)), int(max(model.model_b.stride))],
             "names": [model.model_a.names, model.model_b.names],
+            "inference-size": [model.model_a.infsz, model.model_b.infsz],
+            "image-size": [model.model_a.imgsz, model.model_b.imgsz]
         }
     else:
-        d = {"stride": int(max(model.stride)), "names": model.names}
-    for k, v in d.items():
+        d = {"stride": int(max(model.stride)), 
+             "names": model.names,
+             "inference-size": getattr(model, "infsz", None),
+             "image-size": getattr(model, "imgsz", None)}
+        
+    for k, v in {k: v for k, v in d.items() if v}.items():
         meta = model_onnx.metadata_props.add()
         meta.key, meta.value = k, str(v)
+        LOGGER.info(f"{meta.key}: {meta.value}")
     onnx.save(model_onnx, f)
 
     # Simplify

--- a/export.py
+++ b/export.py
@@ -395,7 +395,6 @@ def export_onnx(model, im, file, opset, dynamic, simplify, prefix=colorstr("ONNX
     for k, v in {k: v for k, v in d.items() if v}.items():
         meta = model_onnx.metadata_props.add()
         meta.key, meta.value = k, str(v)
-        LOGGER.info(f"{meta.key}: {meta.value}")
     onnx.save(model_onnx, f)
 
     # Simplify

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -16,6 +16,7 @@ import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.nn.parallel import DistributedDataParallel as DDP
+from torchvision.transforms import Resize
 
 from utils.general import LOGGER, check_version, colorstr, file_date, git_describe
 
@@ -482,3 +483,22 @@ class ModelEMA:
         default.
         """
         copy_attr(self.ema, model, include, exclude)
+
+
+def get_resize_info(model_or_transform):
+    """
+    Extracts resize information (height and width) from a model's transform 
+    or a standalone transform object.
+    """
+    transforms = getattr(model_or_transform, "transform", None)
+    resize_transform = next((t for t in getattr(transforms, "transforms", []) if isinstance(t, Resize)), None)
+
+    if not resize_transform:
+        return {}
+
+    return {
+        "height": resize_transform.size[0],
+        "width": resize_transform.size[1],
+        "interpolation": resize_transform.interpolation.name.lower(),
+        "antialias": resize_transform.antialias
+    }


### PR DESCRIPTION
## What?
 
Enhanced ONNX export metadata to include inference and image size information for better model compatibility and debugging. 
 
## Why?
 
We often forget important model configuration details and need a way to look them up later. This metadata helps developers quickly access model inference and image size information when working with exported ONNX models.
 
## How?
 
Added inference-size and image-size metadata fields to ONNX exports:

- For DAN models: extracts infsz and imgsz from both model_a and model_b
- For other models: extracts these attributes if available, otherwise sets to None
- Only includes metadata fields that have valid values (filters out None values)


## Backout plan
Remove metadata

## Testing
 
Just tested with an ahoy model:

With resize:

<img width="542" alt="image" src="https://github.com/user-attachments/assets/2b86b86d-7c96-4064-ba73-c61d27a70bb0" />


Without resize:

<img width="553" alt="image" src="https://github.com/user-attachments/assets/c5213174-c531-4c3f-9267-ce01f39d0b60" />



> [!NOTE]
> Im not sure how "trigger" the DAN export code as the DAN is generated with the combine_onnx.py script and i think the export is not used there. Sooo i know its not proper tested and i need a bit of input here :)


