### PR TITLE
CV-392: add perspective augmentation

### DIFF
--- a/data/hyps/hyp.sea-ai.yaml
+++ b/data/hyps/hyp.sea-ai.yaml
@@ -26,7 +26,7 @@ degrees: 10.0  # image rotation (+/- deg)
 translate: 0.1  # image translation (+/- fraction)
 scale: 0.25  # image scale (+/- gain)
 shear: 0.0  # image shear (+/- deg)
-perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
+perspective: 0.0005  # image perspective (+/- fraction), range 0-0.001
 flipud: 0.0  # image flip up-down (probability)
 fliplr: 0.5  # image flip left-right (probability)
 mosaic: 1.0  # image mosaic (probability)


### PR DESCRIPTION
## What?
 
Added perspective transform augmentation to the SEA-AI hyperparameters configuration for RGB training. The perspective transform value was set to 0.0005.
 
## Why?
 
Experiments showed that adding perspective transform augmentation is beneficial for RGB detection performance and improves recall.
 
## How?
 
Modified the data/hyps/hyp.sea-ai.yaml file to include perspective transform augmentation with a value of 0.0005. This augmentation applies a full perspective transformation along both x-axis and y-axis, simulating how objects appear when viewed from different depths or angles. For example, with perspective=0.0005, the perspective is randomly selected within -0.0005 to 0.0005 on the x-axis, and another independent random value is selected within the same range on the y-axis.

## Backout plan

Set perspective to 0.0
 
## Testing
 
Models with perspective settings where trained and evaluated

- Training:  https://wandb.ai/sea-ai/yolo-train/runs/7m5swrxi?nw=nwuserseaaimlops
- Evaluation: https://sea-team.atlassian.net/wiki/spaces/CV/pages/edit-v2/227705110

> [!NOTE]
> For more infos about the augmentation see here: https://arc.net/l/quote/jslfytfn


