### PR TITLE
Bugfix/amp autocast warning

### DIFF
--- a/classify/val.py
+++ b/classify/val.py
@@ -108,7 +108,7 @@ def run(
     action = "validating" if dataloader.dataset.root.stem == "val" else "testing"
     desc = f"{pbar.desc[:-36]}{action:>36}" if pbar else f"{action}"
     bar = tqdm(dataloader, desc, n, not training, bar_format=TQDM_BAR_FORMAT, position=0)
-    with torch.cuda.amp.autocast(enabled=device.type != "cpu"):
+    with torch.amp.autocast("cuda", enabled=device.type != "cpu"):
         for images, labels in bar:
             with dt[0]:
                 images, labels = images.to(device, non_blocking=True), labels.to(device)

--- a/segment/train.py
+++ b/segment/train.py
@@ -386,7 +386,7 @@ def train(hyp, opt, device, callbacks):
                     imgs = nn.functional.interpolate(imgs, size=ns, mode="bilinear", align_corners=False)
 
             # Forward
-            with torch.cuda.amp.autocast(amp):
+            with torch.amp.autocast("cuda", amp):
                 pred = model(imgs)  # forward
                 loss, loss_items = compute_loss(pred, targets.to(device), masks=masks.to(device).float())
                 if RANK != -1:

--- a/train.py
+++ b/train.py
@@ -418,7 +418,7 @@ def train(hyp, opt, device, callbacks):
                     imgs = nn.functional.interpolate(imgs, size=ns, mode="bilinear", align_corners=False)
 
             # Forward
-            with torch.cuda.amp.autocast(amp):
+            with torch.amp.autocast("cuda", amp):
                 pred = model(imgs)  # forward
                 loss, loss_items = compute_loss(pred, targets.to(device))  # loss scaled by batch_size
                 if RANK != -1:

--- a/utils/autobatch.py
+++ b/utils/autobatch.py
@@ -12,7 +12,7 @@ from utils.torch_utils import profile
 
 def check_train_batch_size(model, imgsz=640, amp=True):
     """Checks and computes optimal training batch size for YOLOv5 model, given image size and AMP setting."""
-    with torch.cuda.amp.autocast(amp):
+    with torch.amp.autocast("cuda", amp):
         return autobatch(deepcopy(model).train(), imgsz)  # compute optimal batch size
     
 


### PR DESCRIPTION
## What?

Address the following warning during training with torch 2.7

```
FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.  with torch.cuda.amp.autocast(amp):
```
 
## Why?
 
It pollutes the logs otherwise
 
## How?
 
Replacing `torch.cuda.amp.autocast(amp)` with `torch.amp.autocast("cuda", amp)` where needed.

## Backout plan

Find a way to disable warnings and revert any changes in this PR.
