### PR TITLE
Save weigths paths in exported ONNX models

### DIFF
--- a/export.py
+++ b/export.py
@@ -382,22 +382,21 @@ def export_onnx(model, im, file, opset, dynamic, simplify, prefix=colorstr("ONNX
 
     # Metadata
     if isinstance(model, DAN):
-
         resize_info = [get_resize_info(model.model_a), get_resize_info(model_or_transform=model.model_b)]
-
         d = {
             "stride": [int(max(model.model_a.stride)), int(max(model.model_b.stride))],
             "names": [model.model_a.names, model.model_b.names],
-            "resize": resize_info if any(resize_info) else None
-
+            "resize": resize_info if any(resize_info) else None,
+            "det_weights": [getattr(model.model_a, "obj_det_weights", None), getattr(model.model_b, "obj_det_weights", None)],
+            "hor_weights": [getattr(model.model_a, "hor_det_weights", None), getattr(model.model_b, "hor_det_weights", None)],
         }
-        
     else:
-        
         d = {
             "stride": int(max(model.stride)),
             "names": model.names,
-            "resize": get_resize_info(model)
+            "resize": get_resize_info(model),
+            "det_weights": getattr(model, "obj_det_weights", None),
+            "hor_weights": getattr(model, "hor_det_weights", None),
         }
         
     for k, v in {k: v for k, v in d.items() if v}.items():

--- a/export_ahoy.py
+++ b/export_ahoy.py
@@ -55,7 +55,7 @@ def get_weights_path(weights_path: str) -> str:
     Returns:
         Path to model weights file
     """
-    
+
     # Check if it's a local file first
     if Path(weights_path).exists():
         return weights_path
@@ -67,22 +67,20 @@ def get_weights_path(weights_path: str) -> str:
         return weights_path
 
     api = wandb.Api()
-    
+
     # Try registry first (format: collection:version)
     if ":" in weights_path and "/" not in weights_path.split(":")[0]:
         try:
             collection, version = weights_path.split(":")
             artifact_name = f"wandb-registry-model/{collection}:{version}"
             LOGGER.info(f"Attempting to download from registry: {artifact_name}")
-            
-            artifact_path = api.artifact(name=artifact_name).download(
-                root=Path("artifacts", weights_path)
-            )
+
+            artifact_path = api.artifact(name=artifact_name).download(root=Path("artifacts", weights_path))
             return str(next(Path(artifact_path).glob("*.pt")))
-            
+
         except Exception as e:
             LOGGER.warning(f"Failed to download from registry: {e}")
-    
+
     # Try as direct run artifact (format: entity/project/artifact:version)
     try:
         LOGGER.info(f"Attempting to download as run artifact: {weights_path}")
@@ -90,9 +88,10 @@ def get_weights_path(weights_path: str) -> str:
             root=Path("artifacts", weights_path.replace("/", "_").replace(":", "_"))
         )
         return str(next(Path(artifact_path).glob("*.pt")))
-        
+
     except Exception as e:
         LOGGER.error(f"Failed to download from W&B run: {e}")
+        raise e
 
 
 def _transform_sz(imgsz: int | List[int] | Tuple[int, int]) -> Tuple[int, int]:

--- a/models/custom.py
+++ b/models/custom.py
@@ -383,6 +383,8 @@ class AHOY(nn.Module):
         infsz: Optional[Tuple[int, int]] = None,
     ):
         super().__init__()
+        self.obj_det_weights = obj_det_weigths
+        self.hor_det_weights = hor_det_weights
         self.obj_det = self.load_obj_det(obj_det_weigths, device=device, fp16=fp16, fuse=fuse)
         self.hor_det = self.load_hor_det(hor_det_weights, device=device, fp16=fp16, fuse=fuse)
         self.device = self.obj_det.device
@@ -512,7 +514,7 @@ class AHOY(nn.Module):
     def _preprocessing_hook(module, inputs):
         """Add preprocessing operations to be part of the model."""
 
-        def _preprocess(x):
+        def _preprocess(x: torch.Tensor):
             if len(x.shape) < 1:
                 return x
             if module.transform is not None:


### PR DESCRIPTION
## What?

This PR saves object detection and horizon detection weights paths as metadata in exported ONNX models. Previously, ONNX models only stored stride, names, and resize information.

## Why?

Necessary for traceability and reproducibility when working with exported ONNX models. Stakeholders: **DevOps/MLOps teams** and **developers** who need to track model provenance and debug issues.

## How?

1. **Model Storage** (`models/custom.py`): Added `self.obj_det_weights` and `self.hor_det_weights` attributes to the `AHOY` class
2. **ONNX Export** (`export.py`): Extended metadata to include `det_weights` and `hor_weights` fields (arrays for DAN models, single values for regular models)
3. **Error Handling** (`export_ahoy.py`): Added explicit exception propagation

The weights paths are stored in ONNX `metadata_props` and accessible via standard ONNX tools.

## Backout plan

Nothing, should only make our lives easier ✨ 

## Testing

<img width="613" height="425" alt="image" src="https://github.com/user-attachments/assets/c5c18147-f292-4d37-8e7a-3d93547e0192" />
