### PR TITLE
Fix SeaYOLO TRT7-compatible ONNX export

### DIFF
--- a/export.py
+++ b/export.py
@@ -650,8 +650,8 @@ def export_onnx_trt7_compatible(model, im, file, dynamic, simplify, opset=12, pr
         ```
     """
     LOGGER.info(f"\n{prefix} exporting TensorRT 7 compatible ONNX...")
-    from models.custom import AHOY, DAN
-    if isinstance(model, AHOY):
+    from models.custom import AHOY, DAN, SeaYOLO
+    if isinstance(model, (AHOY, SeaYOLO)):
         grid = model.obj_det.model[-1].anchor_grid
         model.obj_det.model[-1].anchor_grid = [a[..., :1, :1, :] for a in grid]
         export_onnx(model, im, file, opset, dynamic, simplify)  # opset 12


### PR DESCRIPTION
## What?

`SeaYOLO` models crashed with `AttributeError: 'SeaYOLO' object has no attribute 'model'` when exporting with `--trt7-compatible`. The TRT7 export path now correctly handles `SeaYOLO` alongside `AHOY`.

## Why?

Devs exporting `SeaYOLO` to TRT7-compatible ONNX were blocked by this bug.

> **Note — Sentry requires `--trt7-compatible` even on TRT8:**
> Sentry runs TRT 8.0.1 (CUDA 10.2), which does not support the `Cast(uint8 → float32)` ONNX operator. Without `--trt7-compatible`, the export produces a graph with a uint8 input node and a Cast op (from `register_io_hooks`), which fails at TRT engine compilation. The `--trt7-compatible` flag avoids this by using float32 input and shrinking the anchor grid. This flag is needed for **any** TensorRT version that lacks uint8 cast support (TRT7 and early TRT8 releases like 8.0.x).

## How?

`export_onnx_trt7_compatible` had special handling for `AHOY` (which accesses `model.obj_det.model[-1].anchor_grid`) and `DAN`, but `SeaYOLO` fell through to the `else` branch that assumes `model.model[-1]`. Since `SeaYOLO` shares the same `obj_det.model` structure as `AHOY`, the fix adds `SeaYOLO` to the existing `isinstance` check:

```diff
- from models.custom import AHOY, DAN
- if isinstance(model, AHOY):
+ from models.custom import AHOY, DAN, SeaYOLO
+ if isinstance(model, (AHOY, SeaYOLO)):
```

## Testing
<img width="1322" height="652" alt="image" src="https://github.com/user-attachments/assets/4c9b60fc-9c8f-4db4-bb25-5b8f32ec49f4" />

<img width="1317" height="966" alt="image" src="https://github.com/user-attachments/assets/fb63e953-b971-4fbf-9a23-f8bb18bda923" />