### PR TITLE
SEA-393: Register datasets in wandb

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,10 +37,10 @@ dataset = dataset.map_labels("ground_truth_train_det", class_map)
 
 ### Export dataset
 
-Use `docs/fo_to_yolo.py` to export a FiftyOne dataset to YOLOv5 format with optional W&B registration.
+Use `scripts/fo_to_yolo.py` to export a FiftyOne dataset to YOLOv5 format with optional W&B registration.
 
 ```bash
-python docs/fo_to_yolo.py \
+python scripts/fo_to_yolo.py \
   --dataset-name "MY_DATASET" \
   --export-dir "/home/sea-ai/Documents" \
   --class-map "data/class_map.yaml" \
@@ -60,19 +60,19 @@ python docs/fo_to_yolo.py \
 
 ### Combine datasets
 
-Use `docs/combine_datasets.py` to merge multiple exported datasets into a single self-contained dataset for training. All source datasets must share the same class list.
+Use `scripts/combine_datasets.py` to merge multiple exported datasets into a single self-contained dataset for training. All source datasets must share the same class list.
 
 Each entry in `--datasets` can be a local path or a W&B artifact reference — they can be mixed freely.
 
 ```bash
 # Local paths
-python docs/combine_datasets.py \
+python scripts/combine_datasets.py \
   --datasets "/home/sea-ai/Documents/DATASET_A_v0" "/home/sea-ai/Documents/DATASET_B_v0" \
   --output-dir "/home/sea-ai/Documents/COMBINED_v0" \
   --wandb --wandb-entity sea-ai --wandb-collection "my-combined-dataset"
 
 # W&B artifact refs — no local setup needed, downloaded automatically
-python docs/combine_datasets.py \
+python scripts/combine_datasets.py \
   --datasets "sea-ai/dataset-registry/DATASET_A:v0" "sea-ai/dataset-registry/DATASET_B:v0" \
   --wandb --wandb-entity sea-ai --wandb-collection "my-combined-dataset"
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ python docs/fo_to_yolo.py \
 
 ### Combine datasets
 
-Use `docs/combine_datasets.py` to merge multiple exported datasets into a single `dataset.yaml` for training. All source datasets must share the same class list.
+Use `docs/combine_datasets.py` to merge multiple exported datasets into a single self-contained dataset for training. All source datasets must share the same class list.
 
 Each entry in `--datasets` can be a local path or a W&B artifact reference — they can be mixed freely.
 
@@ -68,6 +68,7 @@ Each entry in `--datasets` can be a local path or a W&B artifact reference — t
 # Local paths
 python docs/combine_datasets.py \
   --datasets "/home/sea-ai/Documents/DATASET_A_v0" "/home/sea-ai/Documents/DATASET_B_v0" \
+  --output-dir "/home/sea-ai/Documents/COMBINED_v0" \
   --wandb --wandb-entity sea-ai --wandb-collection "my-combined-dataset"
 
 # W&B artifact refs — no local setup needed, downloaded automatically
@@ -76,11 +77,15 @@ python docs/combine_datasets.py \
   --wandb --wandb-entity sea-ai --wandb-collection "my-combined-dataset"
 ```
 
+- A description is prompted interactively and is **required** to proceed.
 - Local paths and W&B artifact refs can be mixed freely.
-- `--output` and `--download-dir` are optional — both default to a temp directory if not set.
+- `--output-dir` and `--download-dir` are optional — both default to a temp directory if not set.
+- Images and labels from all source datasets are copied into `images/` and `labels/`, prefixed with `d0_`, `d1_`, etc. to avoid filename collisions.
+- `dataset.yaml` uses `path: .` (portable — works wherever the folder is moved or downloaded from W&B).
+- The W&B artifact contains the full combined dataset (images + labels + yaml) — self-contained and usable on any machine.
 - W&B artifact entries are declared as lineage inputs in the uploaded artifact.
-- No data is re-uploaded — only the combined `dataset.yaml` is stored as a W&B artifact.
-- Pass the output YAML directly to training: `python train.py --data /path/to/combined.yaml`.
+- Omit `--wandb-org` to upload the artifact without linking to the Dataset Registry.
+- Pass the output YAML directly to training: `python train.py --data /path/to/combined/dataset.yaml`.
 
 ### Training IR Entrypoint
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,31 +37,50 @@ dataset = dataset.map_labels("ground_truth_train_det", class_map)
 
 ### Export dataset
 
-YOLOv5 uses a defined format for their dataset. Since SEA.AI uses fiftyone for data management, we need to export the dataset in the YOLOv5 format. Luckily, fiftyone has a built-in function to export the dataset in the YOLOv5 format.
+Use `docs/fo_to_yolo.py` to export a FiftyOne dataset to YOLOv5 format with optional W&B registration.
 
-Here's a snippet of the code that exports the dataset:
-```python
-# for IR
-fo_splits = [f"TRAIN_by_sequence", f"VAL_by_sequence"]
-# for RGB
-fo_splits = [f"TRAIN_v0", f"VAL_v0"]
-
-yolo_splits = ["train", "val"]
-
-for fo_split, yolo_split in zip(fo_splits, yolo_splits):
-    split: fo.DatasetView = dataset.match_tags(fo_split)
-    split.export(
-        export_dir="path/to/export/dir",
-        dataset_type=fo.types.YOLOv5Dataset,
-        label_field="ground_truth_train_det",
-        classes=classes,
-        split=yolo_split,
-        export_media=True,
-    )
+```bash
+python docs/fo_to_yolo.py \
+  --dataset-name "MY_DATASET" \
+  --export-dir "/home/sea-ai/Documents" \
+  --class-map "data/class_map.yaml" \
+  --split-mode split \        # split | train | val
+  --split-by trip \           # field name | random (skipped if TRAIN_/VAL_ tags already exist)
+  --noise-ratio 0.25 \        # omit to use all samples
+  --val-ratio 0.2 \
+  --wandb --wandb-entity sea-ai --wandb-org sea-ai-org --wandb-collection "MY_DATASET" \
+  --tags-suffix v0
 ```
 
-> [!note]
-> For more details on how the tags are defined, check the `fo_to_yolo.py` file in this same directory.
+- A description is prompted interactively and is **required** to proceed.
+- The output folder is `<export-dir>/<dataset-name>_<tags-suffix>/`.
+- `dataset.yaml` uses `path: .` (portable — works wherever the folder is moved or downloaded from W&B).
+- If `TRAIN_<suffix>` and `VAL_<suffix>` tags already exist on the samples, the existing split is used automatically.
+- Omit `--wandb` to skip upload entirely. Omit `--wandb-org` to upload the artifact without linking to the Dataset Registry.
+
+### Combine datasets
+
+Use `docs/combine_datasets.py` to merge multiple exported datasets into a single `dataset.yaml` for training. All source datasets must share the same class list.
+
+Each entry in `--datasets` can be a local path or a W&B artifact reference — they can be mixed freely.
+
+```bash
+# Local paths
+python docs/combine_datasets.py \
+  --datasets "/home/sea-ai/Documents/DATASET_A_v0" "/home/sea-ai/Documents/DATASET_B_v0" \
+  --wandb --wandb-entity sea-ai --wandb-collection "my-combined-dataset"
+
+# W&B artifact refs — no local setup needed, downloaded automatically
+python docs/combine_datasets.py \
+  --datasets "sea-ai/dataset-registry/DATASET_A:v0" "sea-ai/dataset-registry/DATASET_B:v0" \
+  --wandb --wandb-entity sea-ai --wandb-collection "my-combined-dataset"
+```
+
+- Local paths and W&B artifact refs can be mixed freely.
+- `--output` and `--download-dir` are optional — both default to a temp directory if not set.
+- W&B artifact entries are declared as lineage inputs in the uploaded artifact.
+- No data is re-uploaded — only the combined `dataset.yaml` is stored as a W&B artifact.
+- Pass the output YAML directly to training: `python train.py --data /path/to/combined.yaml`.
 
 ### Training IR Entrypoint
 

--- a/docs/combine_datasets.py
+++ b/docs/combine_datasets.py
@@ -88,6 +88,29 @@ def download_artifact(ref: str, download_dir: str) -> str:
     return dest
 
 
+def validate_split(out_dir: Path, split: str) -> None:
+    """Raise if a split directory is missing, empty, or has mismatched image/label counts."""
+    img_dir = out_dir / "images" / split
+    lbl_dir = out_dir / "labels" / split
+
+    if not img_dir.exists() or not lbl_dir.exists():
+        raise FileNotFoundError(f"Missing directory for split '{split}': expected {img_dir} and {lbl_dir}")
+
+    image_exts = {".jpg", ".jpeg", ".png"}
+    n_images = sum(1 for f in img_dir.iterdir() if f.suffix.lower() in image_exts)
+    n_labels = sum(1 for f in lbl_dir.iterdir() if f.suffix == ".txt")
+
+    if n_images == 0:
+        raise ValueError(f"No images found in '{img_dir}'")
+    if n_labels == 0:
+        raise ValueError(f"No label files found in '{lbl_dir}'")
+    if n_images != n_labels:
+        raise ValueError(
+            f"Image/label count mismatch in split '{split}': {n_images} images vs {n_labels} labels"
+        )
+    print(f"  {split}: {n_images} images, {n_labels} labels — OK")
+
+
 def copy_split(
     dataset_dir: Path,
     yaml_data: dict,
@@ -262,8 +285,15 @@ def combine_datasets(
         if copy_split(dataset_dir, y, "val", output_path, prefix):
             has_val = True
 
+    # --- Validate ---
+    print("  validating combined dataset...")
+    if has_train:
+        validate_split(output_path, "train")
+    if has_val:
+        validate_split(output_path, "val")
+
     # --- Write combined dataset.yaml ---
-    combined: dict = {"path": ".", "nc": len(classes), "names": classes}
+    combined: dict = {"path": ".", "names": classes}
     if has_train:
         combined["train"] = "./images/train/"
     if has_val:

--- a/docs/combine_datasets.py
+++ b/docs/combine_datasets.py
@@ -1,9 +1,10 @@
 """
-Combine multiple exported YOLO datasets into a single dataset.yaml for training.
+Combine multiple exported YOLO datasets into a single self-contained dataset
+that can be uploaded to W&B and used for training on any machine.
 
 All source datasets must share the same class list (same names in the same order).
-The combined YAML lists each dataset's train/val image directories as separate paths,
-which YOLOv5 natively supports.
+Images and labels from all source datasets are copied into a single output directory.
+The combined dataset.yaml always uses path: . with relative train/val paths.
 
 Each entry in --datasets can be either:
   - A local folder path  (e.g. /home/sea-ai/Documents/DATASET_A_v0)
@@ -15,7 +16,7 @@ declared as lineage inputs in the uploaded artifact.
 Usage (local paths):
 python combine_datasets.py \\
   --datasets "/mnt/datasets/DATASET_A_v0" "/mnt/datasets/DATASET_B_v0" \\
-  --output "/mnt/datasets/combined.yaml" \\       # optional; defaults to a temp file
+  --output-dir "/mnt/datasets/COMBINED_v0" \\
   --wandb --wandb-entity sea-ai --wandb-collection "my-combined-dataset"
 
 Usage (W&B artifacts — no local setup needed):
@@ -29,13 +30,14 @@ python combine_datasets.py \\
   --datasets "/mnt/datasets/DATASET_A_v0" "sea-ai/dataset-registry/DATASET_B:v1" \\
   --wandb --wandb-entity sea-ai --wandb-collection "my-combined-dataset"
 
-  # --download-dir "/mnt/datasets"  → override where W&B artifacts are downloaded
-  # --output "/mnt/datasets/combined.yaml"  → override where the combined YAML is written
+  # --output-dir "/mnt/datasets/COMBINED"  → where the combined dataset is written (default: temp dir)
+  # --download-dir "/mnt/datasets"  → where W&B artifacts are downloaded (default: temp dir)
   # --wandb-org sea-ai-org  → also links to the Dataset Registry
   # A description will be prompted interactively and is required to proceed.
 """
 
 import argparse
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -55,17 +57,6 @@ def read_yaml(path: Path) -> dict:
 def is_wandb_ref(entry: str) -> bool:
     """Return True if entry looks like a W&B artifact ref (entity/project/name:version)."""
     return not Path(entry).exists()
-
-
-def resolve_split_path(dataset_dir: Path, yaml_data: dict, split: str) -> str | None:
-    """Resolve an absolute path for a split (train/val) from a dataset.yaml."""
-    split_entry = yaml_data.get(split)
-    if not split_entry:
-        return None
-    base = Path(yaml_data.get("path", "."))
-    if not base.is_absolute():
-        base = dataset_dir / base
-    return str((base / split_entry).resolve())
 
 
 def validate_classes(yamls: list[tuple[Path, dict]]) -> list[str]:
@@ -90,13 +81,63 @@ def download_artifact(ref: str, download_dir: str) -> str:
     return dest
 
 
+def copy_split(
+    dataset_dir: Path,
+    yaml_data: dict,
+    split: str,
+    output_dir: Path,
+    prefix: str,
+) -> bool:
+    """Copy images and labels for one split into the combined output directory.
+
+    Files are prefixed with *prefix* (e.g. 'd0') to avoid name collisions.
+    Returns True if the split existed and files were copied, False otherwise.
+    """
+    split_entry = yaml_data.get(split)
+    if not split_entry:
+        return False
+
+    base = Path(yaml_data.get("path", "."))
+    if not base.is_absolute():
+        base = (dataset_dir / base).resolve()
+
+    img_src = base / split_entry
+    if not img_src.exists():
+        print(f"  WARNING: image directory not found: {img_src}")
+        return False
+
+    # YOLO convention: labels mirror the images path with 'images' replaced by 'labels'
+    lbl_src = Path(str(img_src).replace("/images/", "/labels/"))
+
+    img_dst = output_dir / "images" / split
+    lbl_dst = output_dir / "labels" / split
+    img_dst.mkdir(parents=True, exist_ok=True)
+    lbl_dst.mkdir(parents=True, exist_ok=True)
+
+    copied = 0
+    for img_file in sorted(img_src.iterdir()):
+        if not img_file.is_file():
+            continue
+        new_stem = f"{prefix}_{img_file.stem}"
+        shutil.copy2(img_file, img_dst / f"{new_stem}{img_file.suffix}")
+        lbl_file = lbl_src / f"{img_file.stem}.txt"
+        if lbl_file.exists():
+            shutil.copy2(lbl_file, lbl_dst / f"{new_stem}.txt")
+        else:
+            (lbl_dst / f"{new_stem}.txt").touch()  # empty = background sample
+        copied += 1
+
+    print(f"    {copied} {split} samples copied (prefix: {prefix})")
+    return True
+
+
 # ---------------------------------------------------------------------------
 # W&B registration
 # ---------------------------------------------------------------------------
 
 
 def register_in_wandb(
-    yaml_path: Path,
+    output_dir: Path,
     description: str,
     dataset_dirs: list[str],
     classes: list[str],
@@ -105,7 +146,7 @@ def register_in_wandb(
     wandb_collection: str,
     wandb_org: str | None,
 ) -> None:
-    """Upload combined YAML to W&B. W&B artifact entries are declared as lineage inputs."""
+    """Upload combined dataset directory to W&B. W&B artifact entries are declared as lineage inputs."""
     import wandb
 
     with wandb.init(
@@ -131,7 +172,7 @@ def register_in_wandb(
             description=description,
             metadata={"datasets": dataset_dirs, "classes": classes},
         )
-        artifact.add_file(str(yaml_path))
+        artifact.add_dir(str(output_dir))
 
         logged = run.log_artifact(artifact)
         logged.wait()
@@ -152,7 +193,7 @@ def register_in_wandb(
 
 def combine_datasets(
     datasets: list[str],
-    output: str | None = None,
+    output_dir: str | None = None,
     description: str = "",
     download_dir: str | None = None,
     register_wandb: bool = False,
@@ -180,13 +221,12 @@ def combine_datasets(
         else:
             local_dirs.append(entry)
 
-    # Resolve output path: default to <download_dir>/combined.yaml or cwd
-    if not output:
-        base = download_dir or tempfile.mkdtemp()
-        output = str(Path(base) / "combined.yaml")
-        print(f"No --output set, writing to: {output}")
+    # Resolve output directory
+    if not output_dir:
+        output_dir = tempfile.mkdtemp()
+        print(f"No --output-dir set, using temp dir: {output_dir}")
 
-    wandb_collection = wandb_collection or Path(output).stem
+    wandb_collection = wandb_collection or Path(output_dir).name
 
     # --- Read and validate ---
     print(f"\nReading {len(local_dirs)} dataset(s)...")
@@ -201,44 +241,50 @@ def combine_datasets(
     classes = validate_classes(yamls)
     print(f"  classes consistent across all datasets: {classes}")
 
-    # --- Build combined paths ---
-    train_paths, val_paths = [], []
-    for dataset_dir, y in yamls:
-        t = resolve_split_path(dataset_dir, y, "train")
-        v = resolve_split_path(dataset_dir, y, "val")
-        if t:
-            train_paths.append(t)
-        if v:
-            val_paths.append(v)
+    # --- Copy images and labels ---
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
 
+    has_train, has_val = False, False
+    print(f"\nCopying dataset files to {output_dir}...")
+    for i, (dataset_dir, y) in enumerate(yamls):
+        prefix = f"d{i}"
+        print(f"  dataset {i}: {dataset_dir}")
+        if copy_split(dataset_dir, y, "train", output_path, prefix):
+            has_train = True
+        if copy_split(dataset_dir, y, "val", output_path, prefix):
+            has_val = True
+
+    # --- Write combined dataset.yaml ---
     combined: dict = {"path": ".", "nc": len(classes), "names": classes}
-    if train_paths:
-        combined["train"] = train_paths
-    if val_paths:
-        combined["val"] = val_paths
+    if has_train:
+        combined["train"] = "images/train"
+    if has_val:
+        combined["val"] = "images/val"
 
-    # --- Write combined YAML ---
-    output_path = Path(output)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w", encoding="utf-8") as f:
+    yaml_path = output_path / "dataset.yaml"
+    with open(yaml_path, "w", encoding="utf-8") as f:
         yaml.dump(combined, f, default_flow_style=False, allow_unicode=True)
 
-    print(f"\nCombined dataset.yaml saved → {output_path}")
-    if train_paths:
-        print(f"  train splits : {len(train_paths)}")
-    if val_paths:
-        print(f"  val splits   : {len(val_paths)}")
+    print(f"\nCombined dataset written → {output_dir}")
+    if has_train:
+        n_train = len(list((output_path / "images" / "train").iterdir()))
+        print(f"  train images : {n_train}")
+    if has_val:
+        n_val = len(list((output_path / "images" / "val").iterdir()))
+        print(f"  val images   : {n_val}")
     print(f"  classes      : {classes}")
-    print(f"\nTrain with: python train.py --data {output_path}")
+    print(f"\nTrain with: python train.py --data {yaml_path}")
 
+    # --- Description ---
     if description:
-        output_path.with_suffix(".description.txt").write_text(description)
+        (output_path / "description.txt").write_text(description)
 
     # --- W&B ---
     if register_wandb:
         print("\nRegistering in Weights & Biases...")
         register_in_wandb(
-            yaml_path=output_path,
+            output_dir=output_path,
             description=description,
             dataset_dirs=local_dirs,
             classes=classes,
@@ -258,7 +304,7 @@ def combine_datasets(
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Combine multiple exported YOLO datasets into a single dataset.yaml.",
+        description="Combine multiple exported YOLO datasets into a single self-contained dataset.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
@@ -272,9 +318,10 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
-        "--output",
+        "--output-dir",
         default=None,
-        help="Path to write the combined dataset.yaml. Defaults to <download-dir>/combined.yaml.",
+        dest="output_dir",
+        help="Directory to write the combined dataset. Defaults to a temp directory.",
     )
     parser.add_argument(
         "--download-dir",
@@ -283,9 +330,9 @@ def parse_args() -> argparse.Namespace:
     )
 
     # Weights & Biases
-    parser.add_argument("--wandb", action="store_true", dest="register_wandb", help="Upload combined YAML to W&B.")
+    parser.add_argument("--wandb", action="store_true", dest="register_wandb", help="Upload combined dataset to W&B.")
     parser.add_argument("--wandb-entity", default=None, help="W&B team entity. Required when --wandb is set.")
-    parser.add_argument("--wandb-collection", default=None, help="Artifact name. Defaults to the output filename stem.")
+    parser.add_argument("--wandb-collection", default=None, help="Artifact name. Defaults to the output directory name.")
     parser.add_argument("--wandb-org", default=None, help="W&B organization entity for Dataset Registry linking.")
 
     return parser.parse_args()

--- a/docs/combine_datasets.py
+++ b/docs/combine_datasets.py
@@ -59,14 +59,21 @@ def is_wandb_ref(entry: str) -> bool:
     return not Path(entry).exists()
 
 
+def names_as_list(names) -> list[str]:
+    """Normalise names to a flat list for comparison, handling both list and dict formats."""
+    if isinstance(names, dict):
+        return [str(names[k]) for k in sorted(names.keys())]
+    return [str(n) for n in names]
+
+
 def validate_classes(yamls: list[tuple[Path, dict]]) -> list[str]:
-    """Ensure all datasets share the same class list and return it."""
-    all_names = [(str(d), tuple(y["names"])) for d, y in yamls]
+    """Ensure all datasets share the same class list. Returns the raw names from the first yaml."""
+    all_names = [(str(d), tuple(names_as_list(y["names"]))) for d, y in yamls]
     unique = set(names for _, names in all_names)
     if len(unique) > 1:
         lines = "\n".join(f"  {d}: {list(names)}" for d, names in all_names)
         raise ValueError(f"Datasets have inconsistent class lists:\n{lines}")
-    return list(yamls[0][1]["names"])
+    return yamls[0][1]["names"]  # return as-is from the source yaml
 
 
 def download_artifact(ref: str, download_dir: str) -> str:
@@ -157,7 +164,7 @@ def register_in_wandb(
         config={
             "description": description,
             "datasets": dataset_dirs,
-            "classes": classes,
+            "classes": names_as_list(classes),
             "source_artifacts": wandb_refs,
         },
     ) as run:
@@ -170,7 +177,7 @@ def register_in_wandb(
             name=wandb_collection,
             type="dataset",
             description=description,
-            metadata={"datasets": dataset_dirs, "classes": classes},
+            metadata={"datasets": dataset_dirs, "classes": names_as_list(classes)},
         )
         artifact.add_dir(str(output_dir))
 
@@ -258,9 +265,9 @@ def combine_datasets(
     # --- Write combined dataset.yaml ---
     combined: dict = {"path": ".", "nc": len(classes), "names": classes}
     if has_train:
-        combined["train"] = "images/train"
+        combined["train"] = "./images/train/"
     if has_val:
-        combined["val"] = "images/val"
+        combined["val"] = "./images/val/"
 
     yaml_path = output_path / "dataset.yaml"
     with open(yaml_path, "w", encoding="utf-8") as f:
@@ -273,7 +280,7 @@ def combine_datasets(
     if has_val:
         n_val = len(list((output_path / "images" / "val").iterdir()))
         print(f"  val images   : {n_val}")
-    print(f"  classes      : {classes}")
+    print(f"  classes      : {names_as_list(classes)}")
     print(f"\nTrain with: python train.py --data {yaml_path}")
 
     # --- Description ---

--- a/docs/combine_datasets.py
+++ b/docs/combine_datasets.py
@@ -271,7 +271,7 @@ def combine_datasets(
 
     yaml_path = output_path / "dataset.yaml"
     with open(yaml_path, "w", encoding="utf-8") as f:
-        yaml.dump(combined, f, default_flow_style=False, allow_unicode=True)
+        yaml.safe_dump(combined, f, default_flow_style=False, allow_unicode=True)
 
     print(f"\nCombined dataset written → {output_dir}")
     if has_train:

--- a/docs/combine_datasets.py
+++ b/docs/combine_datasets.py
@@ -1,0 +1,304 @@
+"""
+Combine multiple exported YOLO datasets into a single dataset.yaml for training.
+
+All source datasets must share the same class list (same names in the same order).
+The combined YAML lists each dataset's train/val image directories as separate paths,
+which YOLOv5 natively supports.
+
+Each entry in --datasets can be either:
+  - A local folder path  (e.g. /home/sea-ai/Documents/DATASET_A_v0)
+  - A W&B artifact ref   (e.g. sea-ai/dataset-registry/DATASET_A:v0)
+
+W&B artifact entries are downloaded automatically to --download-dir and are also
+declared as lineage inputs in the uploaded artifact.
+
+Usage (local paths):
+python combine_datasets.py \\
+  --datasets "/mnt/datasets/DATASET_A_v0" "/mnt/datasets/DATASET_B_v0" \\
+  --output "/mnt/datasets/combined.yaml" \\       # optional; defaults to a temp file
+  --wandb --wandb-entity sea-ai --wandb-collection "my-combined-dataset"
+
+Usage (W&B artifacts — no local setup needed):
+python combine_datasets.py \\
+  --datasets "sea-ai/dataset-registry/DATASET_A:v0" "sea-ai/dataset-registry/DATASET_B:v1" \\
+  --wandb --wandb-entity sea-ai --wandb-collection "my-combined-dataset"
+  # artifacts are downloaded to a temp dir automatically
+
+Usage (mixed):
+python combine_datasets.py \\
+  --datasets "/mnt/datasets/DATASET_A_v0" "sea-ai/dataset-registry/DATASET_B:v1" \\
+  --wandb --wandb-entity sea-ai --wandb-collection "my-combined-dataset"
+
+  # --download-dir "/mnt/datasets"  → override where W&B artifacts are downloaded
+  # --output "/mnt/datasets/combined.yaml"  → override where the combined YAML is written
+  # --wandb-org sea-ai-org  → also links to the Dataset Registry
+  # A description will be prompted interactively and is required to proceed.
+"""
+
+import argparse
+import tempfile
+from pathlib import Path
+
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def read_yaml(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def is_wandb_ref(entry: str) -> bool:
+    """Return True if entry looks like a W&B artifact ref (entity/project/name:version)."""
+    return not Path(entry).exists()
+
+
+def resolve_split_path(dataset_dir: Path, yaml_data: dict, split: str) -> str | None:
+    """Resolve an absolute path for a split (train/val) from a dataset.yaml."""
+    split_entry = yaml_data.get(split)
+    if not split_entry:
+        return None
+    base = Path(yaml_data.get("path", "."))
+    if not base.is_absolute():
+        base = dataset_dir / base
+    return str((base / split_entry).resolve())
+
+
+def validate_classes(yamls: list[tuple[Path, dict]]) -> list[str]:
+    """Ensure all datasets share the same class list and return it."""
+    all_names = [(str(d), tuple(y["names"])) for d, y in yamls]
+    unique = set(names for _, names in all_names)
+    if len(unique) > 1:
+        lines = "\n".join(f"  {d}: {list(names)}" for d, names in all_names)
+        raise ValueError(f"Datasets have inconsistent class lists:\n{lines}")
+    return list(yamls[0][1]["names"])
+
+
+def download_artifact(ref: str, download_dir: str) -> str:
+    """Download a W&B artifact and return its local path."""
+    import wandb
+
+    api = wandb.Api()
+    artifact = api.artifact(ref)
+    artifact_name = ref.split("/")[-1].split(":")[0]
+    dest = str(Path(download_dir) / artifact_name)
+    artifact.download(root=dest)
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# W&B registration
+# ---------------------------------------------------------------------------
+
+
+def register_in_wandb(
+    yaml_path: Path,
+    description: str,
+    dataset_dirs: list[str],
+    classes: list[str],
+    wandb_refs: list[str],
+    wandb_entity: str,
+    wandb_collection: str,
+    wandb_org: str | None,
+) -> None:
+    """Upload combined YAML to W&B. W&B artifact entries are declared as lineage inputs."""
+    import wandb
+
+    with wandb.init(
+        entity=wandb_entity,
+        project="dataset-registry",
+        name=wandb_collection,
+        job_type="dataset-combine",
+        config={
+            "description": description,
+            "datasets": dataset_dirs,
+            "classes": classes,
+            "source_artifacts": wandb_refs,
+        },
+    ) as run:
+        if wandb_refs:
+            print("  linking source artifacts for lineage...")
+            for ref in wandb_refs:
+                run.use_artifact(ref)
+
+        artifact = wandb.Artifact(
+            name=wandb_collection,
+            type="dataset",
+            description=description,
+            metadata={"datasets": dataset_dirs, "classes": classes},
+        )
+        artifact.add_file(str(yaml_path))
+
+        logged = run.log_artifact(artifact)
+        logged.wait()
+        print(f"  artifact '{wandb_collection}' uploaded to '{wandb_entity}/dataset-registry'")
+
+        if wandb_org:
+            run.link_artifact(
+                logged,
+                target_path=f"{wandb_org}/wandb-registry-dataset/{wandb_collection}",
+            )
+            print(f"  artifact linked to registry '{wandb_org}/{wandb_collection}'")
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline
+# ---------------------------------------------------------------------------
+
+
+def combine_datasets(
+    datasets: list[str],
+    output: str | None = None,
+    description: str = "",
+    download_dir: str | None = None,
+    register_wandb: bool = False,
+    wandb_entity: str | None = None,
+    wandb_collection: str | None = None,
+    wandb_org: str | None = None,
+) -> None:
+    if register_wandb and not wandb_entity:
+        raise ValueError("--wandb-entity is required when --wandb is set.")
+
+    # --- Resolve entries: download W&B refs, keep local paths as-is ---
+    local_dirs: list[str] = []
+    wandb_refs: list[str] = []
+
+    for entry in datasets:
+        if is_wandb_ref(entry):
+            if not download_dir:
+                download_dir = tempfile.mkdtemp()
+                print(f"No --download-dir set, using temp dir: {download_dir}")
+            print(f"Downloading artifact '{entry}'...")
+            local_path = download_artifact(entry, download_dir)
+            print(f"  → {local_path}")
+            local_dirs.append(local_path)
+            wandb_refs.append(entry)
+        else:
+            local_dirs.append(entry)
+
+    # Resolve output path: default to <download_dir>/combined.yaml or cwd
+    if not output:
+        base = download_dir or tempfile.mkdtemp()
+        output = str(Path(base) / "combined.yaml")
+        print(f"No --output set, writing to: {output}")
+
+    wandb_collection = wandb_collection or Path(output).stem
+
+    # --- Read and validate ---
+    print(f"\nReading {len(local_dirs)} dataset(s)...")
+    yamls: list[tuple[Path, dict]] = []
+    for d in local_dirs:
+        yaml_path = Path(d) / "dataset.yaml"
+        if not yaml_path.exists():
+            raise FileNotFoundError(f"dataset.yaml not found in '{d}'")
+        yamls.append((Path(d), read_yaml(yaml_path)))
+        print(f"  loaded {yaml_path}")
+
+    classes = validate_classes(yamls)
+    print(f"  classes consistent across all datasets: {classes}")
+
+    # --- Build combined paths ---
+    train_paths, val_paths = [], []
+    for dataset_dir, y in yamls:
+        t = resolve_split_path(dataset_dir, y, "train")
+        v = resolve_split_path(dataset_dir, y, "val")
+        if t:
+            train_paths.append(t)
+        if v:
+            val_paths.append(v)
+
+    combined: dict = {"path": ".", "nc": len(classes), "names": classes}
+    if train_paths:
+        combined["train"] = train_paths
+    if val_paths:
+        combined["val"] = val_paths
+
+    # --- Write combined YAML ---
+    output_path = Path(output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        yaml.dump(combined, f, default_flow_style=False, allow_unicode=True)
+
+    print(f"\nCombined dataset.yaml saved → {output_path}")
+    if train_paths:
+        print(f"  train splits : {len(train_paths)}")
+    if val_paths:
+        print(f"  val splits   : {len(val_paths)}")
+    print(f"  classes      : {classes}")
+    print(f"\nTrain with: python train.py --data {output_path}")
+
+    if description:
+        output_path.with_suffix(".description.txt").write_text(description)
+
+    # --- W&B ---
+    if register_wandb:
+        print("\nRegistering in Weights & Biases...")
+        register_in_wandb(
+            yaml_path=output_path,
+            description=description,
+            dataset_dirs=local_dirs,
+            classes=classes,
+            wandb_refs=wandb_refs,
+            wandb_entity=wandb_entity,
+            wandb_collection=wandb_collection,
+            wandb_org=wandb_org,
+        )
+
+    print("\nDone.")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Combine multiple exported YOLO datasets into a single dataset.yaml.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--datasets",
+        nargs="+",
+        required=True,
+        metavar="PATH_OR_ARTIFACT",
+        help=(
+            "Local folder paths or W&B artifact references "
+            "(e.g. sea-ai/dataset-registry/DATASET_A:v0). Can be mixed."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Path to write the combined dataset.yaml. Defaults to <download-dir>/combined.yaml.",
+    )
+    parser.add_argument(
+        "--download-dir",
+        default=None,
+        help="Directory to download W&B artifacts into. Defaults to a temp directory if any entry in --datasets is a W&B artifact ref.",
+    )
+
+    # Weights & Biases
+    parser.add_argument("--wandb", action="store_true", dest="register_wandb", help="Upload combined YAML to W&B.")
+    parser.add_argument("--wandb-entity", default=None, help="W&B team entity. Required when --wandb is set.")
+    parser.add_argument("--wandb-collection", default=None, help="Artifact name. Defaults to the output filename stem.")
+    parser.add_argument("--wandb-org", default=None, help="W&B organization entity for Dataset Registry linking.")
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    args.description = input("Description (required): ").strip()
+    if not args.description:
+        print("Error: a description is required. Aborting.")
+        return
+    combine_datasets(**vars(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/fo_to_yolo.py
+++ b/docs/fo_to_yolo.py
@@ -230,7 +230,7 @@ def register_in_wandb(
     with wandb.init(
         entity=wandb_entity,
         project="dataset-registry",
-        name=f"{wandb_collection}_{params.get('tags_suffix', 'v0')}",
+        name=wandb_collection,
         config=params,
         job_type="dataset-upload",
     ) as run:

--- a/docs/fo_to_yolo.py
+++ b/docs/fo_to_yolo.py
@@ -293,11 +293,14 @@ def export_dataset(
     print(f"  {len(dataset)} samples" + (f" (filtered by tags {fo_tags})" if fo_tags else ""))
 
     # --- Uniqueness ---
-    if not dataset.has_field("uniqueness"):
-        print("[2/6] Computing uniqueness (first time only)...")
-        fob.compute_uniqueness(dataset)
+    if noise_ratio is not None:
+        if not dataset.has_field("uniqueness"):
+            print("[2/6] Computing uniqueness (first time only)...")
+            fob.compute_uniqueness(dataset)
+        else:
+            print("[2/6] Uniqueness already computed, skipping.")
     else:
-        print("[2/6] Uniqueness already computed, skipping.")
+        print("[2/6] Skipping uniqueness (no subsampling requested).")
 
     # --- Subsample ---
     if noise_ratio is not None:

--- a/docs/fo_to_yolo.py
+++ b/docs/fo_to_yolo.py
@@ -262,7 +262,7 @@ def export_dataset(
     description: str = "",
     split_mode: str = "split",
     split_by: str = "trip",
-    noise_ratio: float = 0.25,
+    noise_ratio: float | None = None,
     val_ratio: float = 0.2,
     use_16bit: bool = False,
     label_field: str = "ground_truth_det",
@@ -300,14 +300,26 @@ def export_dataset(
         print("[2/6] Uniqueness already computed, skipping.")
 
     # --- Subsample ---
-    print(f"[3/6] Subsampling (noise_ratio={noise_ratio})...")
-    subset = subsample_dataset(dataset, noise_ratio, label_field, seed)
-    print(f"  {len(subset)} samples after subsampling")
+    if noise_ratio is not None:
+        print(f"[3/6] Subsampling (noise_ratio={noise_ratio})...")
+        subset = subsample_dataset(dataset, noise_ratio, label_field, seed)
+        print(f"  {len(subset)} samples after subsampling")
+    else:
+        print("[3/6] Skipping subsampling (using all samples).")
+        subset = dataset
 
     # --- Split ---
     print(f"[4/6] Tagging splits (split_mode='{split_mode}')...")
     if split_mode == "split":
-        if split_by == "random":
+        existing_tags = set(subset.count_values("tags").keys())
+        train_tag, val_tag = f"TRAIN_{tags_suffix}", f"VAL_{tags_suffix}"
+        if train_tag in existing_tags and val_tag in existing_tags:
+            n_train = len(subset.match_tags(train_tag))
+            n_val = len(subset.match_tags(val_tag))
+            total = n_train + n_val
+            print(f"  using existing split tags '{train_tag}' / '{val_tag}'")
+            print(f"  train/val split: {n_train/total:.2f} / {n_val/total:.2f}")
+        elif split_by == "random":
             subset = split_random(subset, val_ratio, tags_suffix, seed)
         else:
             subset = split_by_field(subset, split_by, val_ratio, tags_suffix)
@@ -444,8 +456,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--noise-ratio",
         type=float,
-        default=0.25,
-        help="Max ratio of background (unannotated) samples relative to annotated samples.",
+        default=None,
+        help="Max ratio of background (unannotated) samples relative to annotated samples. Omit to use all samples.",
     )
     parser.add_argument("--seed", type=int, default=42, help="Random seed for reproducible subsampling and splits.")
 

--- a/docs/fo_to_yolo.py
+++ b/docs/fo_to_yolo.py
@@ -227,7 +227,7 @@ def register_in_wandb(
     with wandb.init(
         entity=wandb_entity,
         project="dataset-registry",
-        name=wandb_collection,
+        name=f"{wandb_collection}_{params.get('tags_suffix', 'v0')}",
         config=params,
         job_type="dataset-upload",
     ) as run:

--- a/docs/fo_to_yolo.py
+++ b/docs/fo_to_yolo.py
@@ -211,7 +211,7 @@ def export_splits(
             data = yaml.safe_load(f)
         data["path"] = "."
         with open(yaml_path, "w") as f:
-            yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
+            yaml.safe_dump(data, f, default_flow_style=False, allow_unicode=True)
 
 
 def register_in_wandb(

--- a/docs/fo_to_yolo.py
+++ b/docs/fo_to_yolo.py
@@ -22,7 +22,7 @@ python fo_to_yolo.py \\
   --val-ratio 0.2 \\
   --label-field ground_truth_det \\
   --use-16bit \\
-  --wandb --wandb-entity my-org --wandb-collection my-collection \\
+  --wandb --wandb-entity my-team --wandb-org my-org --wandb-collection my-collection \\
   --tags-suffix v2 \\
   --fo-tags tag_one tag_two \\
   --seed 42
@@ -217,8 +217,9 @@ def register_in_wandb(
     params: dict,
     wandb_entity: str,
     wandb_collection: str,
+    wandb_org: str | None = None,
 ) -> None:
-    """Upload dataset artifact to the W&B Dataset Registry."""
+    """Upload dataset artifact to W&B. If wandb_org is provided, also link to the Dataset Registry."""
     import wandb
 
     # A run is required by W&B to upload artifacts. We use a fixed internal
@@ -242,12 +243,14 @@ def register_in_wandb(
 
         logged = run.log_artifact(artifact)
         logged.wait()
-        run.link_artifact(
-            logged,
-            target_path=f"{wandb_entity}/wandb-registry-dataset/{wandb_collection}",
-        )
+        print(f"  artifact '{wandb_collection}' uploaded to project '{wandb_entity}/dataset-registry'")
 
-    print(f"  dataset linked to registry collection '{wandb_collection}'")
+        if wandb_org:
+            run.link_artifact(
+                logged,
+                target_path=f"{wandb_org}/wandb-registry-dataset/{wandb_collection}",
+            )
+            print(f"  artifact linked to registry collection '{wandb_org}/{wandb_collection}'")
 
 
 # ---------------------------------------------------------------------------
@@ -269,6 +272,7 @@ def export_dataset(
     register_wandb: bool = False,
     wandb_entity: str | None = None,
     wandb_collection: str | None = None,
+    wandb_org: str | None = None,
     tags_suffix: str = "v0",
     fo_tags: list[str] | None = None,
     seed: int = 42,
@@ -414,6 +418,7 @@ def export_dataset(
             params=params,
             wandb_entity=wandb_entity,
             wandb_collection=wandb_collection,
+            wandb_org=wandb_org,
         )
 
     fo.delete_dataset(tmp_name)
@@ -472,8 +477,9 @@ def parse_args() -> argparse.Namespace:
 
     # Weights & Biases
     parser.add_argument("--wandb", action="store_true", dest="register_wandb", help="Upload dataset to the W&B Dataset Registry.")
-    parser.add_argument("--wandb-entity", default=None, help="W&B entity (username or org). Required when --wandb is set.")
-    parser.add_argument("--wandb-collection", default=None, help="Registry collection name. Defaults to --dataset-name if not set.")
+    parser.add_argument("--wandb-entity", default=None, help="W&B team entity. Required when --wandb is set.")
+    parser.add_argument("--wandb-collection", default=None, help="Artifact/collection name. Defaults to --dataset-name if not set.")
+    parser.add_argument("--wandb-org", default=None, help="W&B organization entity for Dataset Registry linking. If omitted, artifact is uploaded to the project but not linked to the registry.")
 
     # Misc
     parser.add_argument("--debug", action="store_true", help="Export only 100 samples per split (for quick testing).")

--- a/docs/fo_to_yolo.py
+++ b/docs/fo_to_yolo.py
@@ -1,21 +1,31 @@
 """
-Prepare a dataset for training a YOLOv5 model.
-1. Subsample the dataset to have a ratio of noise samples to annotated samples.
-2. Split the dataset into train and validation based on a field.
-3. Apply a category map to the dataset.
-4. Export the dataset to YOLO format.
+Export a FiftyOne dataset to YOLO format with optional Weights & Biases registration.
+
+Steps:
+1. (Optional) Filter by FiftyOne sample tags.
+2. Subsample to a target annotated/background ratio.
+3. Split into train/val, put all samples in one split, or let the caller decide.
+4. Apply a class-mapping YAML (unmapped labels are dropped).
+5. (Optional) Redirect filepaths to 16-bit PNG images.
+6. Export in YOLOv5 format.
+7. (Optional) Upload dataset, label-distribution plot, class map, and
+   parameters to the W&B Dataset Registry.
 
 Usage:
-python fo_to_yolo.py \
-  --dataset-name "TRAIN_RL_SPLIT_THERMAL_2024_03" \
-  --export-dir "/mnt/datasets/yolo" \
-  --class-map "../../../yolov5/data/class_map.yaml" \
-  --split-by "sequence" \
-  --noise-ratio 0.25 \
-  --val-ratio 0.2 \
-  --tags-suffix "v2" \
-  --fo-tags "tag_one" "tag_two" \
-  --debug
+python fo_to_yolo.py \\
+  --dataset-name "TRAIN_RL_SPLIT_THERMAL_2024_03" \\
+  --export-dir "/mnt/datasets/yolo" \\
+  --class-map "data/class_map.yaml" \\
+  --split-mode split \\
+  --split-by sequence \\
+  --noise-ratio 0.25 \\
+  --val-ratio 0.2 \\
+  --label-field ground_truth_det \\
+  --use-16bit \\
+  --wandb --wandb-entity my-org --wandb-collection my-collection \\
+  --tags-suffix v2 \\
+  --fo-tags tag_one tag_two \\
+  --seed 42
 """
 
 import argparse
@@ -24,8 +34,18 @@ from pathlib import Path
 
 import fiftyone as fo
 import fiftyone.brain as fob
+import matplotlib
+
+matplotlib.use("Agg")  # non-interactive backend; must be set before pyplot import
+import matplotlib.pyplot as plt
+import numpy as np
 import yaml
 from fiftyone import ViewField as F
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def read_yaml(yaml_file: str) -> dict:
@@ -33,266 +53,412 @@ def read_yaml(yaml_file: str) -> dict:
         return yaml.load(f, Loader=yaml.FullLoader)
 
 
-def subsample_dataset(dataset: fo.DatasetView, noise_ratio: float) -> fo.DatasetView:
-    """
-    Subsample the dataset to have a ratio of noise samples to annotated samples.
-    """
-    annotated = dataset.exists("ground_truth_det.detections", True)
-    noise = dataset.exists("ground_truth_det.detections", False)
+def load_dataset(dataset_name: str, fo_tags: list[str] | None = None) -> fo.DatasetView:
+    if dataset_name not in fo.list_datasets():
+        raise ValueError(f"Dataset '{dataset_name}' not found in FiftyOne")
+    dataset = fo.load_dataset(dataset_name)
+    dataset = dataset.match_tags(fo_tags) if fo_tags else dataset
+    if len(dataset) == 0:
+        tag_info = f" with tags {fo_tags}" if fo_tags else ""
+        raise ValueError(f"Dataset '{dataset_name}'{tag_info} is empty")
+    return dataset
 
+
+def subsample_dataset(
+    dataset: fo.DatasetView,
+    noise_ratio: float,
+    label_field: str,
+    seed: int,
+) -> fo.DatasetView:
+    """Keep all annotated samples and up to noise_ratio * n_annotated background samples."""
+    annotated = dataset.exists(f"{label_field}.detections", True)
+    noise = dataset.exists(f"{label_field}.detections", False)
     n_noise = min(len(noise), int(len(annotated) * noise_ratio))
-    return annotated + noise.sort_by("uniqueness", reverse=True).limit(n_noise)
+    return annotated + noise.sort_by("uniqueness", reverse=True).take(n_noise, seed=seed)
 
 
 def split_by_field(
-    dataset: fo.DatasetView, field: str, val_ratio: float, tags_suffix: str
+    dataset: fo.DatasetView,
+    field: str,
+    val_ratio: float,
+    tags_suffix: str,
 ) -> fo.DatasetView:
-    """
-    Split and tag the dataset into train and validation based on a field.
-    """
-    counts = dataset.count_values(field)
-
-    # sort by count
-    counts = dict(sorted(counts.items(), key=lambda x: x[1], reverse=True))
-    # every nth key is a validation group, where n = 1/val_ratio
+    """Tag samples TRAIN/VAL by distributing values of *field* across splits."""
+    counts = dict(sorted(dataset.count_values(field).items(), key=lambda x: x[1], reverse=True))
     val_keys = list(counts.keys())[:: int(1 / val_ratio)]
 
     train_n = sum(v for k, v in counts.items() if k not in val_keys)
     val_n = sum(v for k, v in counts.items() if k in val_keys)
     total_n = train_n + val_n
-    print(f"Ratio train/val split: {train_n/total_n:.2f}:{val_n/total_n:.2f}")
+    print(f"  train/val split: {train_n/total_n:.2f} / {val_n/total_n:.2f}")
 
-    # untag samples with previous tags
     dataset.untag_samples(f"TRAIN_{tags_suffix}")
     dataset.untag_samples(f"VAL_{tags_suffix}")
-
     dataset.match(~F(field).is_in(val_keys)).tag_samples(f"TRAIN_{tags_suffix}")
     dataset.match(F(field).is_in(val_keys)).tag_samples(f"VAL_{tags_suffix}")
     return dataset
 
 
-def apply_category_map(dataset: fo.DatasetView, class_map: dict) -> fo.DatasetView:
-    """
-    Apply a category map to the dataset.
-    """
-    not_none_class_map = {
-        key: value for key, value in class_map.items() if value != "None"
-    }
+def split_random(
+    dataset: fo.DatasetView,
+    val_ratio: float,
+    tags_suffix: str,
+    seed: int,
+) -> fo.DatasetView:
+    """Tag samples TRAIN/VAL via a random split."""
+    import random
 
+    random.seed(seed)
+    ids = list(dataset.values("id"))
+    random.shuffle(ids)
+    n_val = int(len(ids) * val_ratio)
+    val_ids, train_ids = ids[:n_val], ids[n_val:]
+    total_n = len(ids)
+    print(f"  train/val split: {len(train_ids)/total_n:.2f} / {n_val/total_n:.2f}")
+
+    dataset.untag_samples(f"TRAIN_{tags_suffix}")
+    dataset.untag_samples(f"VAL_{tags_suffix}")
+    dataset.select(train_ids).tag_samples(f"TRAIN_{tags_suffix}")
+    dataset.select(val_ids).tag_samples(f"VAL_{tags_suffix}")
+    return dataset
+
+
+def apply_category_map(
+    dataset: fo.DatasetView,
+    class_map: dict,
+    label_field: str,
+) -> fo.DatasetView:
+    """Drop labels not in class_map or mapped to 'None', then remap remaining labels."""
+    keep_labels = [k for k, v in class_map.items() if v != "None"]
     dataset = dataset.filter_labels(
-        "ground_truth_det",
-        F("label").is_in(list(not_none_class_map.keys())),
+        label_field,
+        F("label").is_in(keep_labels),
         only_matches=False,
     )
     dataset.keep()
     dataset.save()
+    return dataset.map_labels(label_field, class_map)
 
-    return dataset.map_labels("ground_truth_det", class_map)
+
+def plot_label_distribution(counts_by_split: dict[str, dict], save_path: str) -> plt.Figure:
+    """Bar chart of label counts per split, saved to *save_path*."""
+    splits = list(counts_by_split.keys())
+    all_labels = sorted(set().union(*[set(c.keys()) for c in counts_by_split.values()]))
+    n_splits = len(splits)
+    bar_width = 0.6 / n_splits
+
+    fig, ax = plt.subplots(figsize=(16, 4))
+    xaxis = np.arange(len(all_labels))
+    for i, split in enumerate(splits):
+        counts = [counts_by_split[split].get(lbl, 0) for lbl in all_labels]
+        ax.bar(xaxis + i * bar_width, counts, label=split, width=bar_width)
+
+    title = "Label distribution"
+    if len(splits) > 1:
+        title += " — " + " / ".join(splits) + " split"
+    ax.set_title(title)
+    ax.set_yscale("log")
+    ax.set_ylabel("count")
+    ax.set_xticks(xaxis + bar_width * (n_splits - 1) / 2)
+    ax.set_xticklabels(all_labels, rotation=45, ha="right")
+    ax.legend()
+    ax.grid(True)
+    fig.tight_layout()
+    fig.savefig(save_path, dpi=150)
+    return fig
 
 
-def export_as_yolo_dataset(
+def export_splits(
     dataset: fo.DatasetView,
-    dataset_name: str,
     tags_suffix: str,
     export_dir: str,
+    dataset_name: str,
+    label_field: str,
     classes: list[str],
+    split_mode: str,
     debug: bool,
-):
-    """
-    Export the dataset to YOLO format.
-    """
-    fo_splits = [f"TRAIN_{tags_suffix}", f"VAL_{tags_suffix}"]
-    yolo_splits = ["train", "val"]
+) -> None:
+    """Export one or both splits to YOLOv5 format."""
+    if split_mode == "split":
+        items = [(f"TRAIN_{tags_suffix}", "train"), (f"VAL_{tags_suffix}", "val")]
+    elif split_mode == "train":
+        items = [(f"TRAIN_{tags_suffix}", "train")]
+    else:
+        items = [(f"VAL_{tags_suffix}", "val")]
 
-    for fo_split, yolo_split in zip(fo_splits, yolo_splits):
-        print(f"📤 Exporting {yolo_split} dataset...")
+    for fo_tag, yolo_split in items:
+        print(f"  exporting '{yolo_split}' split...")
+        split = dataset.match_tags(fo_tag)
         if debug:
-            split: fo.DatasetView = dataset.match_tags(fo_split).take(
-                100, seed=51
-            )  # Tirar take para exportar tudo
-        else:
-            split: fo.DatasetView = dataset.match_tags(fo_split)
+            split = split.take(100, seed=51)
         split.export(
             export_dir=str(Path(export_dir) / dataset_name),
             dataset_type=fo.types.YOLOv5Dataset,
-            label_field="ground_truth_det",
+            label_field=label_field,
             classes=classes,
             split=yolo_split,
             export_media=True,
         )
 
 
-def load_dataset(dataset_name: str, fo_tags: list[str] = None) -> fo.DatasetView:
-    """
-    Load a dataset from FiftyOne.
-    """
-    if dataset_name not in fo.list_datasets():
-        raise ValueError(f"Dataset '{dataset_name}' not found in FiftyOne")
+def register_in_wandb(
+    export_dir: str,
+    dataset_name: str,
+    params: dict,
+    wandb_entity: str,
+    wandb_collection: str,
+) -> None:
+    """Upload dataset artifact to the W&B Dataset Registry."""
+    import wandb
 
-    dataset = fo.load_dataset(dataset_name)
-    dataset = dataset.match_tags(fo_tags) if fo_tags else dataset
+    # A run is required by W&B to upload artifacts. We use a fixed internal
+    # project so it never appears alongside training experiments.
+    with wandb.init(
+        entity=wandb_entity,
+        project="dataset-registry",
+        name=wandb_collection,
+        config=params,
+        job_type="dataset-upload",
+    ) as run:
+        artifact = wandb.Artifact(
+            name=wandb_collection,
+            type="dataset",
+            description=params.get("description", ""),
+            metadata=params,
+        )
+        # Dataset files (images, labels, dataset.yaml, class_map.yaml,
+        # label_distribution.png, description.txt) are all inside out_dir.
+        artifact.add_dir(str(Path(export_dir) / dataset_name))
 
-    if len(dataset) == 0:
-        raise ValueError(
-            f"Dataset '{dataset_name}'{f' with tags {fo_tags}' if fo_tags else ''} is empty"
+        logged = run.log_artifact(artifact)
+        logged.wait()
+        run.link_artifact(
+            logged,
+            target_path=f"{wandb_entity}/wandb-registry-dataset/{wandb_collection}",
         )
 
-    return dataset
+    print(f"  dataset linked to registry collection '{wandb_collection}'")
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline
+# ---------------------------------------------------------------------------
 
 
 def export_dataset(
     dataset_name: str,
-    export_dir: str = "/mnt/datasets/yolo",
-    split_by: str = "sequence",
-    class_map: str = "./yolov5/data/class_map.yaml",
+    export_dir: str,
+    class_map_path: str,
+    description: str = "",
+    split_mode: str = "split",
+    split_by: str = "trip",
     noise_ratio: float = 0.25,
     val_ratio: float = 0.2,
+    use_16bit: bool = False,
+    label_field: str = "ground_truth_det",
+    register_wandb: bool = False,
+    wandb_entity: str | None = None,
+    wandb_collection: str | None = None,
     tags_suffix: str = "v0",
-    fo_tags: list[str] = None,
+    fo_tags: list[str] | None = None,
+    seed: int = 42,
     debug: bool = False,
-):
-    """
-    Prepare a dataset for training a YOLOv5 model.
+) -> None:
+    if register_wandb and not wandb_entity:
+        raise ValueError("--wandb-entity is required when --wandb is set")
+    wandb_collection = wandb_collection or dataset_name
 
-    Parameters
-    ----------
-    dataset_name : str
-        Name of the dataset to fetch and split.
-    export_dir : str, optional
-        Directory to export the training data, by default "/mnt/datasets/yolo".
-    split_by : str, optional
-        DB field to split the training data, by default "trip".
-    class_map : str, optional
-        Path to the class map, by default "./yolov5/data/class_map.yaml".
-    noise_ratio : float, optional
-        Ratio of noise samples to add to the training set, by default 0.25.
-    val_ratio : float, optional
-        Ratio of validation samples to add to the training set, by default 0.2.
-    tags_suffix : str, optional
-        Suffix to add to the "TRAIN" and "VAL" tags, by default "v0".
-    fo_tags : str or list of str (separated by space), by default None
-        Tags to filter the dataset in FiftyOne.
-    debug : bool, optional
-        Debug mode, by default False.
-    """
-    _ = [fo.delete_dataset(d) for d in fo.list_datasets() if d.startswith("tmp_")]
-    Path(export_dir).mkdir(parents=True, exist_ok=True)
-    # make sure export_dir is empty
-    shutil.rmtree((Path(export_dir) / dataset_name).as_posix(), ignore_errors=True)
+    # Clean up stale tmp datasets from previous interrupted runs
+    for d in fo.list_datasets():
+        if d.startswith("tmp_"):
+            fo.delete_dataset(d)
 
+    out_dir = Path(export_dir) / dataset_name
+    shutil.rmtree(out_dir, ignore_errors=True)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # --- Load ---
+    print(f"[1/6] Loading dataset '{dataset_name}'...")
     dataset = load_dataset(dataset_name, fo_tags)
-    print(
-        f"📡 Found {len(dataset)} samples in dataset {dataset_name}"
-        + (f" with tags {fo_tags}" if fo_tags else "")
-    )
-    print("🔍 Computing uniqueness...")
+    print(f"  {len(dataset)} samples" + (f" (filtered by tags {fo_tags})" if fo_tags else ""))
+
+    # --- Uniqueness ---
     if not dataset.has_field("uniqueness"):
+        print("[2/6] Computing uniqueness (first time only)...")
         fob.compute_uniqueness(dataset)
+    else:
+        print("[2/6] Uniqueness already computed, skipping.")
 
-    print("🎯 Subsampling dataset...")
-    subset = subsample_dataset(dataset, noise_ratio)
+    # --- Subsample ---
+    print(f"[3/6] Subsampling (noise_ratio={noise_ratio})...")
+    subset = subsample_dataset(dataset, noise_ratio, label_field, seed)
+    print(f"  {len(subset)} samples after subsampling")
 
-    print(f"⛵ Splitting train/val based on {split_by}...")
-    subset = split_by_field(subset, split_by, val_ratio, tags_suffix)
+    # --- Split ---
+    print(f"[4/6] Tagging splits (split_mode='{split_mode}')...")
+    if split_mode == "split":
+        if split_by == "random":
+            subset = split_random(subset, val_ratio, tags_suffix, seed)
+        else:
+            subset = split_by_field(subset, split_by, val_ratio, tags_suffix)
+    else:
+        tag = f"TRAIN_{tags_suffix}" if split_mode == "train" else f"VAL_{tags_suffix}"
+        subset.untag_samples(tag)
+        subset.tag_samples(tag)
+        print(f"  all {len(subset)} samples tagged as '{split_mode}'")
 
-    print("🏋️ Creating temporal training dataset...")
+    # Clone to a tmp dataset so we can mutate it (filepath swap, label filter)
+    # without touching the original.
     tmp_name = f"tmp_{dataset_name}"
     try:
         export = subset.clone(tmp_name)
     except ValueError:
-        print(f"Loading existing dataset {tmp_name}")
+        print(f"  tmp dataset '{tmp_name}' already exists, reusing it")
         export = fo.load_dataset(tmp_name)
 
-    print("🗺️ Applying category map...")
-    class_map = read_yaml(class_map)
-    export = apply_category_map(export, class_map)
+    # --- Category map ---
+    print("[5/6] Applying category map...")
+    class_map = read_yaml(class_map_path)
+    export = apply_category_map(export, class_map, label_field)
 
-    classes = export.distinct("ground_truth_det.detections.label")
-    missing_classes = set(class_map.values()) - set(classes) - {"None"}
-    assert not missing_classes, f"Missing classes: {missing_classes}"
-    print(f"🏷️ Classes:\n{classes}")
+    classes = export.distinct(f"{label_field}.detections.label")
+    missing = set(class_map.values()) - set(classes) - {"None"}
+    if missing:
+        print(f"  WARNING: the following mapped classes have no samples: {missing}")
+    print(f"  classes: {classes}")
 
-    print("📜 Replacing filepaths to point to raw data...")
-    filepaths = export.values("filepath")
-    filepaths = [fp.replace("8Bit", "16Bit").replace("jpg", "png") for fp in filepaths]
-    export.set_values("filepath", filepaths)
+    # --- 16-bit filepath swap ---
+    if use_16bit:
+        print("  switching filepaths to 16-bit PNG...")
+        filepaths = [
+            fp.replace("8Bit", "16Bit").replace("jpg", "png")
+            for fp in export.values("filepath")
+        ]
+        export.set_values("filepath", filepaths)
 
-    print("📤 Exporting YOLO dataset...")
-    export_as_yolo_dataset(
-        export,
-        dataset_name,
-        tags_suffix,
-        export_dir,
-        classes,
-        debug,
-    )
+    # --- Export ---
+    print("[6/6] Exporting to YOLO format...")
+    export_splits(export, tags_suffix, export_dir, dataset_name, label_field, classes, split_mode, debug)
 
-    print(f"🗑️ Delete temporal dataset {tmp_name}")
+    # --- Label distribution plot ---
+    counts_by_split: dict[str, dict] = {}
+    if split_mode in ("split", "train"):
+        counts_by_split["train"] = export.match_tags(f"TRAIN_{tags_suffix}").count_values(
+            f"{label_field}.detections.label"
+        )
+    if split_mode in ("split", "val"):
+        counts_by_split["val"] = export.match_tags(f"VAL_{tags_suffix}").count_values(
+            f"{label_field}.detections.label"
+        )
+    plot_path = str(out_dir / "label_distribution.png")
+    fig = plot_label_distribution(counts_by_split, plot_path)
+    plt.close(fig)
+    print(f"  label distribution saved → {plot_path}")
+
+    # --- Class map YAML ---
+    class_map_yaml = out_dir / "class_map.yaml"
+    with open(class_map_yaml, "w", encoding="utf-8") as f:
+        yaml.dump(class_map, f, default_flow_style=False, allow_unicode=True)
+    print(f"  class map saved → {class_map_yaml}")
+
+    # --- Description ---
+    if description:
+        desc_path = out_dir / "description.txt"
+        desc_path.write_text(description)
+        print(f"  description saved → {desc_path}")
+
+    # --- W&B registration ---
+    if register_wandb:
+        print("Registering in Weights & Biases...")
+        params = {
+            "description": description,
+            "dataset_name": dataset_name,
+            "split_mode": split_mode,
+            "split_by": split_by if split_mode == "split" else None,
+            "noise_ratio": noise_ratio,
+            "val_ratio": val_ratio if split_mode == "split" else None,
+            "use_16bit": use_16bit,
+            "label_field": label_field,
+            "fo_tags": fo_tags,
+            "tags_suffix": tags_suffix,
+            "seed": seed,
+        }
+        register_in_wandb(
+            export_dir=export_dir,
+            dataset_name=dataset_name,
+            params=params,
+            wandb_entity=wandb_entity,
+            wandb_collection=wandb_collection,
+        )
+
     fo.delete_dataset(tmp_name)
+    print(f"\nDone. Dataset exported to: {out_dir}")
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="Fetch and split training data")
-    parser.add_argument(
-        "--dataset-name",
-        type=str,
-        help="Name of the dataset to fetch and split",
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Export a FiftyOne dataset to YOLO format.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
+
+    # Required
+    parser.add_argument("--dataset-name", required=True, help="FiftyOne dataset name")
+    parser.add_argument("--export-dir", required=True, help="Local directory to write the exported dataset")
+    parser.add_argument("--class-map", required=True, dest="class_map_path", help="Path to class-mapping YAML file")
+
+    # Split behaviour
     parser.add_argument(
-        "--export-dir",
-        type=str,
-        default="/mnt/datasets/yolo",
-        help="Directory to export the training data",
-    )
-    parser.add_argument(
-        "--class-map",
-        type=str,
-        default="./yolov5/data/class_map.yaml",
-        help="Path to the class map",
+        "--split-mode",
+        choices=["split", "train", "val"],
+        default="split",
+        help="'split' → export train+val; 'train' → all samples go to train; 'val' → all samples go to val",
     )
     parser.add_argument(
         "--split-by",
-        type=str,
         default="trip",
-        help="DB field to split the training data",
-    )
-    parser.add_argument(
-        "--noise-ratio",
-        type=float,
-        default=0.25,
-        help="Ratio of noise samples to add to the training set",
+        help="Metadata field used to assign train/val groups, or 'random' for a random split. Only used with --split-mode split.",
     )
     parser.add_argument(
         "--val-ratio",
         type=float,
         default=0.2,
-        help="Ratio of validation samples to add to the training set",
-    )
-    parser.add_argument(
-        "--tags-suffix",
-        type=str,
-        default="v0",
-        help="Suffix to add to the tags",
+        help="Fraction of samples for validation. Only used with --split-mode split.",
     )
 
+    # Sampling
     parser.add_argument(
-        "--fo-tags",
-        type=str,
-        nargs="+",
-        default=None,
-        help="Tags to filter the dataset in FiftyOne (separated by space for multiple tags, by default None, ex --fo-tags tag1 tag2)",
+        "--noise-ratio",
+        type=float,
+        default=0.25,
+        help="Max ratio of background (unannotated) samples relative to annotated samples.",
     )
+    parser.add_argument("--seed", type=int, default=42, help="Random seed for reproducible subsampling and splits.")
 
-    parser.add_argument(
-        "--debug",
-        action="store_true",
-        help="Debug mode",
-    )
+    # Export options
+    parser.add_argument("--label-field", default="ground_truth_det", help="FiftyOne label field to export.")
+    parser.add_argument("--use-16bit", action="store_true", help="Redirect filepaths to 16-bit PNG images instead of 8-bit JPEG.")
+    parser.add_argument("--tags-suffix", default="v0", help="Suffix appended to TRAIN_/VAL_ sample tags in FiftyOne.")
+    parser.add_argument("--fo-tags", nargs="+", default=None, metavar="TAG", help="Pre-filter the FiftyOne dataset to samples with these tags.")
+
+    # Weights & Biases
+    parser.add_argument("--wandb", action="store_true", dest="register_wandb", help="Upload dataset to the W&B Dataset Registry.")
+    parser.add_argument("--wandb-entity", default=None, help="W&B entity (username or org). Required when --wandb is set.")
+    parser.add_argument("--wandb-collection", default=None, help="Registry collection name. Defaults to --dataset-name if not set.")
+
+    # Misc
+    parser.add_argument("--debug", action="store_true", help="Export only 100 samples per split (for quick testing).")
+
     return parser.parse_args()
 
 
-def main():
+def main() -> None:
     args = parse_args()
+    args.description = input("Dataset description (press Enter to skip): ").strip()
     export_dataset(**vars(args))
 
 

--- a/docs/fo_to_yolo.py
+++ b/docs/fo_to_yolo.py
@@ -3,8 +3,8 @@ Export a FiftyOne dataset to YOLO format with optional Weights & Biases registra
 
 Steps:
 1. (Optional) Filter by FiftyOne sample tags.
-2. Subsample to a target annotated/background ratio.
-3. Split into train/val, put all samples in one split, or let the caller decide.
+2. (Optional) Subsample to a target annotated/background ratio; omit to use all samples.
+3. Split into train/val, put all samples in one split, or use existing split tags.
 4. Apply a class-mapping YAML (unmapped labels are dropped).
 5. (Optional) Redirect filepaths to 16-bit PNG images.
 6. Export in YOLOv5 format.
@@ -18,7 +18,7 @@ python fo_to_yolo.py \\
   --class-map "data/class_map.yaml" \\
   --split-mode split \\
   --split-by sequence \\
-  --noise-ratio 0.25 \\
+  --noise-ratio 0.25 \\        # omit to use all samples
   --val-ratio 0.2 \\
   --label-field ground_truth_det \\
   --use-16bit \\

--- a/docs/fo_to_yolo.py
+++ b/docs/fo_to_yolo.py
@@ -287,7 +287,8 @@ def export_dataset(
         if d.startswith("tmp_"):
             fo.delete_dataset(d)
 
-    out_dir = Path(export_dir) / dataset_name
+    folder_name = f"{dataset_name}_{tags_suffix}"
+    out_dir = Path(export_dir) / folder_name
     shutil.rmtree(out_dir, ignore_errors=True)
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -367,7 +368,7 @@ def export_dataset(
 
     # --- Export ---
     print("[6/6] Exporting to YOLO format...")
-    export_splits(export, tags_suffix, export_dir, dataset_name, label_field, classes, split_mode, debug)
+    export_splits(export, tags_suffix, export_dir, folder_name, label_field, classes, split_mode, debug)
 
     # --- Label distribution plot ---
     counts_by_split: dict[str, dict] = {}
@@ -414,7 +415,7 @@ def export_dataset(
         }
         register_in_wandb(
             export_dir=export_dir,
-            dataset_name=dataset_name,
+            dataset_name=folder_name,
             params=params,
             wandb_entity=wandb_entity,
             wandb_collection=wandb_collection,

--- a/docs/fo_to_yolo.py
+++ b/docs/fo_to_yolo.py
@@ -490,7 +490,10 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    args.description = input("Dataset description (press Enter to skip): ").strip()
+    args.description = input("Dataset description (required): ").strip()
+    if not args.description:
+        print("Error: a description is required. Aborting.")
+        return
     export_dataset(**vars(args))
 
 

--- a/docs/fo_to_yolo.py
+++ b/docs/fo_to_yolo.py
@@ -16,16 +16,19 @@ python fo_to_yolo.py \\
   --dataset-name "TRAIN_RL_SPLIT_THERMAL_2024_03" \\
   --export-dir "/mnt/datasets/yolo" \\
   --class-map "data/class_map.yaml" \\
-  --split-mode split \\
-  --split-by sequence \\
-  --noise-ratio 0.25 \\        # omit to use all samples
+  --split-mode split \\       # split | train | val
+  --split-by sequence \\      # field name | random (ignored if split tags already exist)
+  --noise-ratio 0.25 \\       # omit to use all samples
   --val-ratio 0.2 \\
   --label-field ground_truth_det \\
   --use-16bit \\
-  --wandb --wandb-entity my-team --wandb-org my-org --wandb-collection my-collection \\
-  --tags-suffix v2 \\
-  --fo-tags tag_one tag_two \\
+  --wandb --wandb-entity sea-ai --wandb-org sea-ai-org --wandb-collection my-collection \\  # omit --wandb to skip upload entirely
+                                                                                          # omit --wandb-org to upload artifact but skip registry linking (it will not great a dataset in the registry, but the artifact will still be available in the project and can be linked manually later)
+                                                                                          # omit --wandb-collection to use --dataset-name as the artifact name
+  --tags-suffix v0 \\   #dataset version suffix for the TRAIN_/VAL_ tags (e.g. v0, v1, etc.); only relevant if --split-mode is split
+  --fo-tags tag_one tag_two \\   # optional pre-filtering by FiftyOne sample tags; omit to use all samples in the dataset
   --seed 42
+  # A description will be prompted interactively and is required to proceed.
 """
 
 import argparse

--- a/docs/fo_to_yolo.py
+++ b/docs/fo_to_yolo.py
@@ -200,6 +200,16 @@ def export_splits(
             export_media=True,
         )
 
+    # Patch dataset.yaml: replace the absolute 'path' with '.' so the dataset
+    # is portable (works wherever the folder is placed or downloaded from W&B).
+    yaml_path = Path(export_dir) / dataset_name / "dataset.yaml"
+    if yaml_path.exists():
+        with open(yaml_path) as f:
+            data = yaml.safe_load(f)
+        data["path"] = "."
+        with open(yaml_path, "w") as f:
+            yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
+
 
 def register_in_wandb(
     export_dir: str,

--- a/docs/fo_to_yolo.py
+++ b/docs/fo_to_yolo.py
@@ -53,7 +53,7 @@ from fiftyone import ViewField as F
 
 def read_yaml(yaml_file: str) -> dict:
     with open(yaml_file, "r", encoding="utf-8") as f:
-        return yaml.load(f, Loader=yaml.FullLoader)
+        return yaml.safe_load(f)
 
 
 def load_dataset(dataset_name: str, fo_tags: list[str] | None = None) -> fo.DatasetView:
@@ -391,7 +391,7 @@ def export_dataset(
     # --- Class map YAML ---
     class_map_yaml = out_dir / "class_map.yaml"
     with open(class_map_yaml, "w", encoding="utf-8") as f:
-        yaml.dump(class_map, f, default_flow_style=False, allow_unicode=True)
+        yaml.safe_dump(class_map, f, default_flow_style=False, allow_unicode=True)
     print(f"  class map saved → {class_map_yaml}")
 
     # --- Description ---

--- a/docs/fo_to_yolo.py
+++ b/docs/fo_to_yolo.py
@@ -143,6 +143,29 @@ def apply_category_map(
     return dataset.map_labels(label_field, class_map)
 
 
+def validate_split(out_dir: Path, split: str) -> None:
+    """Raise if a split directory is missing, empty, or has mismatched image/label counts."""
+    img_dir = out_dir / "images" / split
+    lbl_dir = out_dir / "labels" / split
+
+    if not img_dir.exists() or not lbl_dir.exists():
+        raise FileNotFoundError(f"Missing directory for split '{split}': expected {img_dir} and {lbl_dir}")
+
+    image_exts = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif"}
+    n_images = sum(1 for f in img_dir.iterdir() if f.suffix.lower() in image_exts)
+    n_labels = sum(1 for f in lbl_dir.iterdir() if f.suffix == ".txt")
+
+    if n_images == 0:
+        raise ValueError(f"No images found in '{img_dir}'")
+    if n_labels == 0:
+        raise ValueError(f"No label files found in '{lbl_dir}'")
+    if n_images != n_labels:
+        raise ValueError(
+            f"Image/label count mismatch in split '{split}': {n_images} images vs {n_labels} labels"
+        )
+    print(f"  {split}: {n_images} images, {n_labels} labels — OK")
+
+
 def plot_label_distribution(counts_by_split: dict[str, dict], save_path: str) -> plt.Figure:
     """Bar chart of label counts per split, saved to *save_path*."""
     splits = list(counts_by_split.keys())
@@ -372,6 +395,13 @@ def export_dataset(
     # --- Export ---
     print("[6/6] Exporting to YOLO format...")
     export_splits(export, tags_suffix, export_dir, folder_name, label_field, classes, split_mode, debug)
+
+    # --- Validate ---
+    print("  validating export...")
+    if split_mode in ("split", "train"):
+        validate_split(out_dir, "train")
+    if split_mode in ("split", "val"):
+        validate_split(out_dir, "val")
 
     # --- Label distribution plot ---
     counts_by_split: dict[str, dict] = {}

--- a/docs/fo_to_yolo.py
+++ b/docs/fo_to_yolo.py
@@ -77,7 +77,7 @@ def subsample_dataset(
     annotated = dataset.exists(f"{label_field}.detections", True)
     noise = dataset.exists(f"{label_field}.detections", False)
     n_noise = min(len(noise), int(len(annotated) * noise_ratio))
-    return annotated + noise.sort_by("uniqueness", reverse=True).take(n_noise, seed=seed)
+    return annotated + noise.sort_by("uniqueness", reverse=True).limit(n_noise)
 
 
 def split_by_field(

--- a/scripts/combine_datasets.py
+++ b/scripts/combine_datasets.py
@@ -33,6 +33,7 @@ python combine_datasets.py \\
   # --output-dir "/mnt/datasets/COMBINED"  → where the combined dataset is written (default: temp dir)
   # --download-dir "/mnt/datasets"  → where W&B artifacts are downloaded (default: temp dir)
   # --wandb-org sea-ai-org  → also links to the Dataset Registry
+  # W&B versions artifacts by content hash: a new version is only created when the combined files differ from the previous upload
   # A description will be prompted interactively and is required to proceed.
 """
 
@@ -184,11 +185,20 @@ def register_in_wandb(
         print(f"  artifact '{wandb_collection}' uploaded to '{wandb_entity}/dataset-registry'")
 
         if wandb_org:
-            run.link_artifact(
-                logged,
-                target_path=f"{wandb_org}/wandb-registry-dataset/{wandb_collection}",
-            )
-            print(f"  artifact linked to registry '{wandb_org}/{wandb_collection}'")
+            try:
+                run.link_artifact(
+                    logged,
+                    target_path=f"{wandb_org}/wandb-registry-dataset/{wandb_collection}",
+                )
+                print(f"  artifact linked to registry '{wandb_org}/{wandb_collection}'")
+            except wandb.errors.CommError as e:
+                if "Duplicate entry" in str(e):
+                    print(
+                        f"  artifact version already linked to registry '{wandb_org}/{wandb_collection}' "
+                        f"(content unchanged since last upload — no new version created)"
+                    )
+                else:
+                    raise
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/combine_datasets.py
+++ b/scripts/combine_datasets.py
@@ -41,17 +41,14 @@ import shutil
 import tempfile
 from pathlib import Path
 
+from utils.dataset_utils import validate_split
+
 import yaml
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def read_yaml(path: Path) -> dict:
-    with open(path, encoding="utf-8") as f:
-        return yaml.safe_load(f)
 
 
 def is_wandb_ref(entry: str) -> bool:
@@ -87,28 +84,6 @@ def download_artifact(ref: str, download_dir: str) -> str:
     artifact.download(root=dest)
     return dest
 
-
-def validate_split(out_dir: Path, split: str) -> None:
-    """Raise if a split directory is missing, empty, or has mismatched image/label counts."""
-    img_dir = out_dir / "images" / split
-    lbl_dir = out_dir / "labels" / split
-
-    if not img_dir.exists() or not lbl_dir.exists():
-        raise FileNotFoundError(f"Missing directory for split '{split}': expected {img_dir} and {lbl_dir}")
-
-    image_exts = {".jpg", ".jpeg", ".png"}
-    n_images = sum(1 for f in img_dir.iterdir() if f.suffix.lower() in image_exts)
-    n_labels = sum(1 for f in lbl_dir.iterdir() if f.suffix == ".txt")
-
-    if n_images == 0:
-        raise ValueError(f"No images found in '{img_dir}'")
-    if n_labels == 0:
-        raise ValueError(f"No label files found in '{lbl_dir}'")
-    if n_images != n_labels:
-        raise ValueError(
-            f"Image/label count mismatch in split '{split}': {n_images} images vs {n_labels} labels"
-        )
-    print(f"  {split}: {n_images} images, {n_labels} labels — OK")
 
 
 def copy_split(
@@ -265,7 +240,7 @@ def combine_datasets(
         yaml_path = Path(d) / "dataset.yaml"
         if not yaml_path.exists():
             raise FileNotFoundError(f"dataset.yaml not found in '{d}'")
-        yamls.append((Path(d), read_yaml(yaml_path)))
+        yamls.append((Path(d), yaml.safe_load(yaml_path.read_text(encoding="utf-8"))))
         print(f"  loaded {yaml_path}")
 
     classes = validate_classes(yamls)

--- a/scripts/fo_to_yolo.py
+++ b/scripts/fo_to_yolo.py
@@ -33,27 +33,26 @@ python fo_to_yolo.py \\
 
 import argparse
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 import fiftyone as fo
 import fiftyone.brain as fob
 import matplotlib
+from utils.general import LOGGER
 
 matplotlib.use("Agg")  # non-interactive backend; must be set before pyplot import
 import matplotlib.pyplot as plt
 import numpy as np
 import yaml
 from fiftyone import ViewField as F
+from utils.dataset_utils import validate_split
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def read_yaml(yaml_file: str) -> dict:
-    with open(yaml_file, "r", encoding="utf-8") as f:
-        return yaml.safe_load(f)
 
 
 def load_dataset(dataset_name: str, fo_tags: list[str] | None = None) -> fo.DatasetView:
@@ -71,7 +70,6 @@ def subsample_dataset(
     dataset: fo.DatasetView,
     noise_ratio: float,
     label_field: str,
-    seed: int,
 ) -> fo.DatasetView:
     """Keep all annotated samples and up to noise_ratio * n_annotated background samples."""
     annotated = dataset.exists(f"{label_field}.detections", True)
@@ -93,7 +91,7 @@ def split_by_field(
     train_n = sum(v for k, v in counts.items() if k not in val_keys)
     val_n = sum(v for k, v in counts.items() if k in val_keys)
     total_n = train_n + val_n
-    print(f"  train/val split: {train_n/total_n:.2f} / {val_n/total_n:.2f}")
+    LOGGER.info(f"  train/val split: {train_n/total_n:.2f} / {val_n/total_n:.2f}")
 
     dataset.untag_samples(f"TRAIN_{tags_suffix}")
     dataset.untag_samples(f"VAL_{tags_suffix}")
@@ -117,7 +115,7 @@ def split_random(
     n_val = int(len(ids) * val_ratio)
     val_ids, train_ids = ids[:n_val], ids[n_val:]
     total_n = len(ids)
-    print(f"  train/val split: {len(train_ids)/total_n:.2f} / {n_val/total_n:.2f}")
+    LOGGER.info(f"  train/val split: {len(train_ids)/total_n:.2f} / {n_val/total_n:.2f}")
 
     dataset.untag_samples(f"TRAIN_{tags_suffix}")
     dataset.untag_samples(f"VAL_{tags_suffix}")
@@ -131,39 +129,17 @@ def apply_category_map(
     class_map: dict,
     label_field: str,
 ) -> fo.DatasetView:
-    """Drop labels not in class_map or mapped to 'None', then remap remaining labels."""
+    """Drop labels not in class_map or mapped to 'None', then remap remaining labels.
+
+    Returns a lazy view — the original dataset is never mutated.
+    """
     keep_labels = [k for k, v in class_map.items() if v != "None"]
-    dataset = dataset.filter_labels(
-        label_field,
-        F("label").is_in(keep_labels),
-        only_matches=False,
+    return (
+        dataset
+        .filter_labels(label_field, F("label").is_in(keep_labels), only_matches=False)
+        .map_labels(label_field, class_map)
     )
-    dataset.keep()
-    dataset.save()
-    return dataset.map_labels(label_field, class_map)
 
-
-def validate_split(out_dir: Path, split: str) -> None:
-    """Raise if a split directory is missing, empty, or has mismatched image/label counts."""
-    img_dir = out_dir / "images" / split
-    lbl_dir = out_dir / "labels" / split
-
-    if not img_dir.exists() or not lbl_dir.exists():
-        raise FileNotFoundError(f"Missing directory for split '{split}': expected {img_dir} and {lbl_dir}")
-
-    image_exts = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif"}
-    n_images = sum(1 for f in img_dir.iterdir() if f.suffix.lower() in image_exts)
-    n_labels = sum(1 for f in lbl_dir.iterdir() if f.suffix == ".txt")
-
-    if n_images == 0:
-        raise ValueError(f"No images found in '{img_dir}'")
-    if n_labels == 0:
-        raise ValueError(f"No label files found in '{lbl_dir}'")
-    if n_images != n_labels:
-        raise ValueError(
-            f"Image/label count mismatch in split '{split}': {n_images} images vs {n_labels} labels"
-        )
-    print(f"  {split}: {n_images} images, {n_labels} labels — OK")
 
 
 def plot_label_distribution(counts_by_split: dict[str, dict], save_path: str) -> plt.Figure:
@@ -213,7 +189,7 @@ def export_splits(
         items = [(f"VAL_{tags_suffix}", "val")]
 
     for fo_tag, yolo_split in items:
-        print(f"  exporting '{yolo_split}' split...")
+        LOGGER.info(f"  exporting '{yolo_split}' split...")
         split = dataset.match_tags(fo_tag)
         if debug:
             split = split.take(100, seed=51)
@@ -269,14 +245,46 @@ def register_in_wandb(
 
         logged = run.log_artifact(artifact)
         logged.wait()
-        print(f"  artifact '{wandb_collection}' uploaded to project '{wandb_entity}/dataset-registry'")
+        LOGGER.info(f"  artifact '{wandb_collection}' uploaded to project '{wandb_entity}/dataset-registry'")
 
         if wandb_org:
             run.link_artifact(
                 logged,
                 target_path=f"{wandb_org}/wandb-registry-dataset/{wandb_collection}",
             )
-            print(f"  artifact linked to registry collection '{wandb_org}/{wandb_collection}'")
+            LOGGER.info(f"  artifact linked to registry collection '{wandb_org}/{wandb_collection}'")
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ExportConfig:
+    dataset_name: str
+    export_dir: str
+    class_map_path: str
+    description: str = ""
+    split_mode: Literal["split", "train", "val"] = "split"
+    split_by: str = "trip"
+    noise_ratio: float | None = None
+    val_ratio: float = 0.2
+    use_16bit: bool = False
+    label_field: str = "ground_truth_det"
+    register_wandb: bool = False
+    wandb_entity: str | None = None
+    wandb_collection: str | None = None
+    wandb_org: str | None = None
+    tags_suffix: str = "v0"
+    fo_tags: list[str] | None = None
+    seed: int = 42
+    debug: bool = False
+
+    def __post_init__(self) -> None:
+        valid_modes = {"split", "train", "val"}
+        if self.split_mode not in valid_modes:
+            raise ValueError(f"split_mode must be one of {valid_modes}, got '{self.split_mode}'")
 
 
 # ---------------------------------------------------------------------------
@@ -284,108 +292,78 @@ def register_in_wandb(
 # ---------------------------------------------------------------------------
 
 
-def export_dataset(
-    dataset_name: str,
-    export_dir: str,
-    class_map_path: str,
-    description: str = "",
-    split_mode: str = "split",
-    split_by: str = "trip",
-    noise_ratio: float | None = None,
-    val_ratio: float = 0.2,
-    use_16bit: bool = False,
-    label_field: str = "ground_truth_det",
-    register_wandb: bool = False,
-    wandb_entity: str | None = None,
-    wandb_collection: str | None = None,
-    wandb_org: str | None = None,
-    tags_suffix: str = "v0",
-    fo_tags: list[str] | None = None,
-    seed: int = 42,
-    debug: bool = False,
-) -> None:
-    if register_wandb and not wandb_entity:
+def export_dataset(cfg: ExportConfig) -> None:
+    if cfg.register_wandb and not cfg.wandb_entity:
         raise ValueError("--wandb-entity is required when --wandb is set")
-    wandb_collection = wandb_collection or dataset_name
+    wandb_collection = cfg.wandb_collection or cfg.dataset_name
 
-    # Clean up stale tmp datasets from previous interrupted runs
-    for d in fo.list_datasets():
-        if d.startswith("tmp_"):
-            fo.delete_dataset(d)
-
-    folder_name = f"{dataset_name}_{tags_suffix}"
-    out_dir = Path(export_dir) / folder_name
+    folder_name = f"{cfg.dataset_name}_{cfg.tags_suffix}"
+    out_dir = Path(cfg.export_dir) / folder_name
     shutil.rmtree(out_dir, ignore_errors=True)
     out_dir.mkdir(parents=True, exist_ok=True)
 
     # --- Load ---
-    print(f"[1/6] Loading dataset '{dataset_name}'...")
-    dataset = load_dataset(dataset_name, fo_tags)
-    print(f"  {len(dataset)} samples" + (f" (filtered by tags {fo_tags})" if fo_tags else ""))
+    LOGGER.info(f"[1/6] Loading dataset '{cfg.dataset_name}'...")
+    dataset = load_dataset(cfg.dataset_name, cfg.fo_tags)
+    LOGGER.info(f"  {len(dataset)} samples" + (f" (filtered by tags {cfg.fo_tags})" if cfg.fo_tags else ""))
 
     # --- Uniqueness ---
-    if noise_ratio is not None:
+    if cfg.noise_ratio is not None:
         if not dataset.has_field("uniqueness"):
-            print("[2/6] Computing uniqueness (first time only)...")
+            LOGGER.info("[2/6] Computing uniqueness (first time only)...")
             fob.compute_uniqueness(dataset)
         else:
-            print("[2/6] Uniqueness already computed, skipping.")
+            LOGGER.info("[2/6] Uniqueness already computed, skipping.")
     else:
-        print("[2/6] Skipping uniqueness (no subsampling requested).")
+        LOGGER.info("[2/6] Skipping uniqueness (no subsampling requested).")
 
     # --- Subsample ---
-    if noise_ratio is not None:
-        print(f"[3/6] Subsampling (noise_ratio={noise_ratio})...")
-        subset = subsample_dataset(dataset, noise_ratio, label_field, seed)
-        print(f"  {len(subset)} samples after subsampling")
+    if cfg.noise_ratio is not None:
+        LOGGER.info(f"[3/6] Subsampling (noise_ratio={cfg.noise_ratio})...")
+        subset = subsample_dataset(dataset, cfg.noise_ratio, cfg.label_field)
+        LOGGER.info(f"  {len(subset)} samples after subsampling")
     else:
-        print("[3/6] Skipping subsampling (using all samples).")
+        LOGGER.info("[3/6] Skipping subsampling (using all samples).")
         subset = dataset
 
     # --- Split ---
-    print(f"[4/6] Tagging splits (split_mode='{split_mode}')...")
-    if split_mode == "split":
+    LOGGER.info(f"[4/6] Tagging splits (split_mode='{cfg.split_mode}')...")
+    if cfg.split_mode == "split":
         existing_tags = set(subset.count_values("tags").keys())
-        train_tag, val_tag = f"TRAIN_{tags_suffix}", f"VAL_{tags_suffix}"
+        train_tag, val_tag = f"TRAIN_{cfg.tags_suffix}", f"VAL_{cfg.tags_suffix}"
         if train_tag in existing_tags and val_tag in existing_tags:
             n_train = len(subset.match_tags(train_tag))
             n_val = len(subset.match_tags(val_tag))
             total = n_train + n_val
-            print(f"  using existing split tags '{train_tag}' / '{val_tag}'")
-            print(f"  train/val split: {n_train/total:.2f} / {n_val/total:.2f}")
-        elif split_by == "random":
-            subset = split_random(subset, val_ratio, tags_suffix, seed)
+            LOGGER.info(f"  using existing split tags '{train_tag}' / '{val_tag}'")
+            LOGGER.info(f"  train/val split: {n_train/total:.2f} / {n_val/total:.2f}")
+        elif cfg.split_by == "random":
+            subset = split_random(subset, cfg.val_ratio, cfg.tags_suffix, cfg.seed)
         else:
-            subset = split_by_field(subset, split_by, val_ratio, tags_suffix)
+            subset = split_by_field(subset, cfg.split_by, cfg.val_ratio, cfg.tags_suffix)
     else:
-        tag = f"TRAIN_{tags_suffix}" if split_mode == "train" else f"VAL_{tags_suffix}"
+        tag = f"TRAIN_{cfg.tags_suffix}" if cfg.split_mode == "train" else f"VAL_{cfg.tags_suffix}"
         subset.untag_samples(tag)
         subset.tag_samples(tag)
-        print(f"  all {len(subset)} samples tagged as '{split_mode}'")
-
-    # Clone to a tmp dataset so we can mutate it (filepath swap, label filter)
-    # without touching the original.
-    tmp_name = f"tmp_{dataset_name}"
-    try:
-        export = subset.clone(tmp_name)
-    except ValueError:
-        print(f"  tmp dataset '{tmp_name}' already exists, reusing it")
-        export = fo.load_dataset(tmp_name)
+        LOGGER.info(f"  all {len(subset)} samples tagged as '{cfg.split_mode}'")
 
     # --- Category map ---
-    print("[5/6] Applying category map...")
-    class_map = read_yaml(class_map_path)
-    export = apply_category_map(export, class_map, label_field)
+    LOGGER.info("[5/6] Applying category map...")
+    class_map = yaml.safe_load(Path(cfg.class_map_path).read_text(encoding="utf-8"))
+    export = apply_category_map(subset, class_map, cfg.label_field)
 
-    classes = export.distinct(f"{label_field}.detections.label")
+    classes = export.distinct(f"{cfg.label_field}.detections.label")
     missing = set(class_map.values()) - set(classes) - {"None"}
     if missing:
-        print(f"  WARNING: the following mapped classes have no samples: {missing}")
-    print(f"  classes: {classes}")
+        LOGGER.warning(f"  the following mapped classes have no samples: {missing}")
+    LOGGER.info(f"  classes: {classes}")
 
     # --- 16-bit filepath swap ---
-    if use_16bit:
-        print("  switching filepaths to 16-bit PNG...")
+    # set_values mutates a dataset, so we clone into a tmp dataset only when needed.
+    tmp_name = f"tmp_{cfg.dataset_name}"
+    if cfg.use_16bit:
+        LOGGER.info("  switching filepaths to 16-bit PNG...")
+        export = export.clone(tmp_name)
         filepaths = [
             fp.replace("8Bit", "16Bit").replace("jpg", "png")
             for fp in export.values("filepath")
@@ -393,70 +371,71 @@ def export_dataset(
         export.set_values("filepath", filepaths)
 
     # --- Export ---
-    print("[6/6] Exporting to YOLO format...")
-    export_splits(export, tags_suffix, export_dir, folder_name, label_field, classes, split_mode, debug)
+    LOGGER.info("[6/6] Exporting to YOLO format...")
+    export_splits(export, cfg.tags_suffix, cfg.export_dir, folder_name, cfg.label_field, classes, cfg.split_mode, cfg.debug)
 
     # --- Validate ---
-    print("  validating export...")
-    if split_mode in ("split", "train"):
+    LOGGER.info("  validating export...")
+    if cfg.split_mode in ("split", "train"):
         validate_split(out_dir, "train")
-    if split_mode in ("split", "val"):
+    if cfg.split_mode in ("split", "val"):
         validate_split(out_dir, "val")
 
     # --- Label distribution plot ---
     counts_by_split: dict[str, dict] = {}
-    if split_mode in ("split", "train"):
-        counts_by_split["train"] = export.match_tags(f"TRAIN_{tags_suffix}").count_values(
-            f"{label_field}.detections.label"
+    if cfg.split_mode in ("split", "train"):
+        counts_by_split["train"] = export.match_tags(f"TRAIN_{cfg.tags_suffix}").count_values(
+            f"{cfg.label_field}.detections.label"
         )
-    if split_mode in ("split", "val"):
-        counts_by_split["val"] = export.match_tags(f"VAL_{tags_suffix}").count_values(
-            f"{label_field}.detections.label"
+    if cfg.split_mode in ("split", "val"):
+        counts_by_split["val"] = export.match_tags(f"VAL_{cfg.tags_suffix}").count_values(
+            f"{cfg.label_field}.detections.label"
         )
     plot_path = str(out_dir / "label_distribution.png")
     fig = plot_label_distribution(counts_by_split, plot_path)
     plt.close(fig)
-    print(f"  label distribution saved → {plot_path}")
+    LOGGER.info(f"  label distribution saved → {plot_path}")
 
     # --- Class map YAML ---
     class_map_yaml = out_dir / "class_map.yaml"
     with open(class_map_yaml, "w", encoding="utf-8") as f:
         yaml.safe_dump(class_map, f, default_flow_style=False, allow_unicode=True)
-    print(f"  class map saved → {class_map_yaml}")
+    LOGGER.info(f"  class map saved → {class_map_yaml}")
 
     # --- Description ---
-    if description:
+    if cfg.description:
         desc_path = out_dir / "description.txt"
-        desc_path.write_text(description)
-        print(f"  description saved → {desc_path}")
+        desc_path.write_text(cfg.description)
+        LOGGER.info(f"  description saved → {desc_path}")
 
     # --- W&B registration ---
-    if register_wandb:
-        print("Registering in Weights & Biases...")
+    if cfg.register_wandb:
+        LOGGER.info("Registering in Weights & Biases...")
         params = {
-            "description": description,
-            "dataset_name": dataset_name,
-            "split_mode": split_mode,
-            "split_by": split_by if split_mode == "split" else None,
-            "noise_ratio": noise_ratio,
-            "val_ratio": val_ratio if split_mode == "split" else None,
-            "use_16bit": use_16bit,
-            "label_field": label_field,
-            "fo_tags": fo_tags,
-            "tags_suffix": tags_suffix,
-            "seed": seed,
+            "description": cfg.description,
+            "dataset_name": cfg.dataset_name,
+            "split_mode": cfg.split_mode,
+            "split_by": cfg.split_by if cfg.split_mode == "split" else None,
+            "noise_ratio": cfg.noise_ratio,
+            "val_ratio": cfg.val_ratio if cfg.split_mode == "split" else None,
+            "use_16bit": cfg.use_16bit,
+            "label_field": cfg.label_field,
+            "fo_tags": cfg.fo_tags,
+            "tags_suffix": cfg.tags_suffix,
+            "seed": cfg.seed,
         }
         register_in_wandb(
-            export_dir=export_dir,
+            export_dir=cfg.export_dir,
             dataset_name=folder_name,
             params=params,
-            wandb_entity=wandb_entity,
+            wandb_entity=cfg.wandb_entity,
             wandb_collection=wandb_collection,
-            wandb_org=wandb_org,
+            wandb_org=cfg.wandb_org,
         )
 
-    fo.delete_dataset(tmp_name)
-    print(f"\nDone. Dataset exported to: {out_dir}")
+    if cfg.use_16bit:
+        fo.delete_dataset(tmp_name)
+    LOGGER.info(f"\nDone. Dataset exported to: {out_dir}")
 
 
 # ---------------------------------------------------------------------------
@@ -523,11 +502,11 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    args.description = input("Dataset description (required): ").strip()
-    if not args.description:
-        print("Error: a description is required. Aborting.")
+    description = input("Dataset description (required): ").strip()
+    if not description:
+        LOGGER.error("Error: a description is required. Aborting.")
         return
-    export_dataset(**vars(args))
+    export_dataset(ExportConfig(**vars(args), description=description))
 
 
 if __name__ == "__main__":

--- a/scripts/fo_to_yolo.py
+++ b/scripts/fo_to_yolo.py
@@ -23,8 +23,9 @@ python fo_to_yolo.py \\
   --label-field ground_truth_det \\
   --use-16bit \\
   --wandb --wandb-entity sea-ai --wandb-org sea-ai-org --wandb-collection my-collection \\  # omit --wandb to skip upload entirely
-                                                                                          # omit --wandb-org to upload artifact but skip registry linking (it will not great a dataset in the registry, but the artifact will still be available in the project and can be linked manually later)
+                                                                                          # omit --wandb-org to upload artifact but skip registry linking (it will not create a dataset in the registry, but the artifact will still be available in the project and can be linked manually later)
                                                                                           # omit --wandb-collection to use --dataset-name as the artifact name
+                                                                                          # W&B versions artifacts by content hash: a new version is only created when the exported files differ from the previous upload
   --tags-suffix v0 \\   #dataset version suffix for the TRAIN_/VAL_ tags (e.g. v0, v1, etc.); only relevant if --split-mode is split
   --fo-tags tag_one tag_two \\   # optional pre-filtering by FiftyOne sample tags; omit to use all samples in the dataset
   --seed 42
@@ -248,11 +249,20 @@ def register_in_wandb(
         LOGGER.info(f"  artifact '{wandb_collection}' uploaded to project '{wandb_entity}/dataset-registry'")
 
         if wandb_org:
-            run.link_artifact(
-                logged,
-                target_path=f"{wandb_org}/wandb-registry-dataset/{wandb_collection}",
-            )
-            LOGGER.info(f"  artifact linked to registry collection '{wandb_org}/{wandb_collection}'")
+            try:
+                run.link_artifact(
+                    logged,
+                    target_path=f"{wandb_org}/wandb-registry-dataset/{wandb_collection}",
+                )
+                LOGGER.info(f"  artifact linked to registry collection '{wandb_org}/{wandb_collection}'")
+            except wandb.errors.CommError as e:
+                if "Duplicate entry" in str(e):
+                    LOGGER.warning(
+                        f"  artifact version already linked to registry collection '{wandb_org}/{wandb_collection}' "
+                        f"(content unchanged since last upload — no new version created)"
+                    )
+                else:
+                    raise
 
 
 # ---------------------------------------------------------------------------

--- a/utils/dataset_utils.py
+++ b/utils/dataset_utils.py
@@ -1,0 +1,28 @@
+import logging
+from pathlib import Path
+
+LOGGER = logging.getLogger(__name__)
+
+IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif"}
+
+
+def validate_split(out_dir: Path, split: str) -> None:
+    """Raise if a split directory is missing, empty, or has mismatched image/label counts."""
+    img_dir = out_dir / "images" / split
+    lbl_dir = out_dir / "labels" / split
+
+    if not img_dir.exists() or not lbl_dir.exists():
+        raise FileNotFoundError(f"Missing directory for split '{split}': expected {img_dir} and {lbl_dir}")
+
+    n_images = sum(1 for f in img_dir.iterdir() if f.suffix.lower() in IMAGE_EXTS)
+    n_labels = sum(1 for f in lbl_dir.iterdir() if f.suffix == ".txt")
+
+    if n_images == 0:
+        raise ValueError(f"No images found in '{img_dir}'")
+    if n_labels == 0:
+        raise ValueError(f"No label files found in '{lbl_dir}'")
+    if n_images != n_labels:
+        raise ValueError(
+            f"Image/label count mismatch in split '{split}': {n_images} images vs {n_labels} labels"
+        )
+    LOGGER.info(f"  {split}: {n_images} images, {n_labels} labels — OK")


### PR DESCRIPTION
## What?

Introduces two new scripts under `docs/`: `fo_to_yolo.py` for exporting FiftyOne datasets to YOLOv5 format, and `combine_datasets.py` for merging multiple YOLO datasets into a single self-contained dataset. Both scripts support optional Weights & Biases artifact registration.

## Why?

Standardises how training datasets are prepared, versioned, and shared across the team. Previously there was no reproducible pipeline for going from a FiftyOne dataset to a training-ready artifact tracked in W&B.

## How?

### `fo_to_yolo.py` — FiftyOne → YOLO export

| Step | Description |
|---|---|
| Load & filter | Load a FiftyOne dataset, optionally filter by sample tags |
| Subsample | Keep all annotated samples + up to `noise_ratio × n_annotated` background samples selected by uniqueness score (skipped if `--noise-ratio` not set) |
| Split | Tag samples `TRAIN_<suffix>` / `VAL_<suffix>` by field, random, or reuse existing tags |
| Class map | Drop unmapped labels, remap remaining via a YAML class map |
| Export | Write YOLOv5 format to `<export-dir>/<dataset-name>_<suffix>/` with portable `path: .` and `names` in `{index: name}` dict format |
| W&B | Upload full dataset directory as artifact; optionally link to Dataset Registry |

### `combine_datasets.py` — merge multiple YOLO datasets

- Accepts any mix of local folder paths and W&B artifact refs in `--datasets`
- Copies images and labels into a single output directory, prefixed `d0_`, `d1_`, … to avoid filename collisions
- Validates that all sources share the same class list; copies `names` verbatim from the first source yaml
- Uploads the full combined dataset (images + labels + yaml) to W&B — self-contained and usable on any machine
- Declares source W&B artifacts as lineage inputs

## Backout plan

Both scripts are standalone tools under `docs/` and do not touch any training or inference code. Reverting is as simple as not running them.

## Testing

**Export:**
```bash
python docs/fo_to_yolo.py \
  --dataset-name "TRAIN_RL_SPLIT_THERMAL_2024_03" \
  --export-dir "/mnt/datasets/yolo" \
  --class-map "data/class_map.yaml" \
  --split-mode split \
  --split-by sequence \
  --noise-ratio 0.25 \
  --val-ratio 0.2 \
  --wandb --wandb-entity sea-ai --wandb-org sea-ai-org --wandb-collection my-collection \
  --tags-suffix v0
```
Omit `--wandb` to skip W&B upload entirely and only export to the local machine.
Verify: `<export-dir>/TRAIN_RL_SPLIT_THERMAL_2024_03_v0/` contains `images/`, `labels/`, `dataset.yaml`, `label_distribution.png`. Check `dataset.yaml` has `path: .` and `names` as a dict.

**Combine (local paths):**
```bash
python docs/combine_datasets.py \
  --datasets "/mnt/datasets/DATASET_A_v0" "/mnt/datasets/DATASET_B_v0" \
  --output-dir "/mnt/datasets/COMBINED_v0" \
  --wandb --wandb-entity sea-ai --wandb-org sea-ai-org --wandb-collection "my-combined-dataset"
```

**Combine (W&B artifacts):**
```bash
python docs/combine_datasets.py \
  --datasets "sea-ai/dataset-registry/DATASET_A:v0" "sea-ai/dataset-registry/DATASET_B:v1" \
  --wandb --wandb-entity sea-ai --wandb-org sea-ai-org --wandb-collection "my-combined-dataset"
```
Verify: `images/train/` contains files from both datasets with `d0_` and `d1_` prefixes. `dataset.yaml` names match the source datasets exactly.

For both export and combine check the following link for the artifacts in weights and biases if you use the wandb flags: https://wandb.ai/orgs/sea-ai-org/registry/dataset