### PR TITLE
downloading the samples does not repeat for wandb cache and temporary…

### DIFF
--- a/scripts/combine_datasets.py
+++ b/scripts/combine_datasets.py
@@ -38,6 +38,7 @@ python combine_datasets.py \\
 """
 
 import argparse
+import os
 import shutil
 import tempfile
 from pathlib import Path
@@ -74,13 +75,13 @@ def validate_classes(yamls: list[tuple[Path, dict]]) -> list[str]:
     return yamls[0][1]["names"]  # return as-is from the source yaml
 
 
-def download_artifact(ref: str, download_dir: str | None) -> str:
-    """Download a W&B artifact and return its local path.
+def download_artifact(ref: str, download_dir: str | None) -> tuple[str, str | None]:
+    """Download a W&B artifact and return (local_path, tmp_dir_to_cleanup).
 
     The W&B cache is always skipped (skip_cache=True). If *download_dir* is
-    None the artifact is placed under a fresh temp directory in /tmp.
-    If *download_dir* is given the artifact is placed under
-    ``<download_dir>/<artifact_name>/``.
+    None the artifact is placed under a fresh temp directory in /tmp and the
+    temp parent is returned as the second element for the caller to clean up.
+    If *download_dir* is given the second element is None.
     """
     import wandb
 
@@ -89,13 +90,14 @@ def download_artifact(ref: str, download_dir: str | None) -> str:
     artifact = api.artifact(ref)
 
     if download_dir is None:
-        dest = str(Path(tempfile.mkdtemp(dir="/tmp", prefix="wandb_")) / artifact_name)
+        tmp_parent = tempfile.mkdtemp(dir="/tmp", prefix="wandb_")
+        dest = str(Path(tmp_parent) / artifact_name)
         artifact.download(root=dest, skip_cache=True)
-        return dest
+        return dest, tmp_parent
 
     dest = str(Path(download_dir) / artifact_name)
     artifact.download(root=dest, skip_cache=True)
-    return dest
+    return dest, None
 
 
 
@@ -167,6 +169,43 @@ def register_in_wandb(
     """Upload combined dataset directory to W&B. W&B artifact entries are declared as lineage inputs."""
     import wandb
 
+    # Redirect W&B artifact cache to a temp dir so ~/.cache/wandb/artifacts
+    # does not accumulate large dataset files after each upload.
+    _prev_cache = os.environ.get("WANDB_CACHE_DIR")
+    _tmp_cache = tempfile.mkdtemp(prefix="wandb_cache_")
+    os.environ["WANDB_CACHE_DIR"] = _tmp_cache
+
+    try:
+        _do_register_in_wandb(
+            wandb=wandb,
+            output_dir=output_dir,
+            description=description,
+            dataset_dirs=dataset_dirs,
+            classes=classes,
+            wandb_refs=wandb_refs,
+            wandb_entity=wandb_entity,
+            wandb_collection=wandb_collection,
+            wandb_org=wandb_org,
+        )
+    finally:
+        shutil.rmtree(_tmp_cache, ignore_errors=True)
+        if _prev_cache is not None:
+            os.environ["WANDB_CACHE_DIR"] = _prev_cache
+        else:
+            os.environ.pop("WANDB_CACHE_DIR", None)
+
+
+def _do_register_in_wandb(
+    wandb,
+    output_dir: Path,
+    description: str,
+    dataset_dirs: list[str],
+    classes: list[str],
+    wandb_refs: list[str],
+    wandb_entity: str,
+    wandb_collection: str,
+    wandb_org: str | None,
+) -> None:
     with wandb.init(
         entity=wandb_entity,
         project="dataset-registry",
@@ -234,16 +273,19 @@ def combine_datasets(
     # --- Resolve entries: download W&B refs, keep local paths as-is ---
     local_dirs: list[str] = []
     wandb_refs: list[str] = []
+    tmp_download_dirs: list[str] = []
 
     for entry in datasets:
         if is_wandb_ref(entry):
             if not download_dir:
                 print(f"No --download-dir set, using W&B artifact cache.")
             print(f"Downloading artifact '{entry}'...")
-            local_path = download_artifact(entry, download_dir)
+            local_path, tmp_parent = download_artifact(entry, download_dir)
             print(f"  → {local_path}")
             local_dirs.append(local_path)
             wandb_refs.append(entry)
+            if tmp_parent:
+                tmp_download_dirs.append(tmp_parent)
         else:
             local_dirs.append(entry)
 
@@ -280,6 +322,11 @@ def combine_datasets(
             has_train = True
         if copy_split(dataset_dir, y, "val", output_path, prefix):
             has_val = True
+
+    # --- Cleanup temp download dirs (no longer needed after copy) ---
+    for d in tmp_download_dirs:
+        shutil.rmtree(d, ignore_errors=True)
+    tmp_download_dirs.clear()
 
     # --- Validate ---
     print("  validating combined dataset...")

--- a/scripts/combine_datasets.py
+++ b/scripts/combine_datasets.py
@@ -74,12 +74,20 @@ def validate_classes(yamls: list[tuple[Path, dict]]) -> list[str]:
     return yamls[0][1]["names"]  # return as-is from the source yaml
 
 
-def download_artifact(ref: str, download_dir: str) -> str:
-    """Download a W&B artifact and return its local path."""
+def download_artifact(ref: str, download_dir: str | None) -> str:
+    """Download a W&B artifact and return its local path.
+
+    If *download_dir* is None the artifact is downloaded to the W&B cache
+    (``~/.cache/wandb/artifacts/``) and the cached path is returned directly,
+    avoiding a second copy on disk.  If *download_dir* is given the artifact
+    is placed under ``<download_dir>/<artifact_name>/`` as before.
+    """
     import wandb
 
     api = wandb.Api()
     artifact = api.artifact(ref)
+    if download_dir is None:
+        return artifact.download()
     artifact_name = ref.split("/")[-1].split(":")[0]
     dest = str(Path(download_dir) / artifact_name)
     artifact.download(root=dest)
@@ -226,8 +234,7 @@ def combine_datasets(
     for entry in datasets:
         if is_wandb_ref(entry):
             if not download_dir:
-                download_dir = tempfile.mkdtemp()
-                print(f"No --download-dir set, using temp dir: {download_dir}")
+                print(f"No --download-dir set, using W&B artifact cache.")
             print(f"Downloading artifact '{entry}'...")
             local_path = download_artifact(entry, download_dir)
             print(f"  → {local_path}")

--- a/scripts/combine_datasets.py
+++ b/scripts/combine_datasets.py
@@ -38,12 +38,11 @@ python combine_datasets.py \\
 """
 
 import argparse
-import os
 import shutil
 import tempfile
 from pathlib import Path
 
-from utils.dataset_utils import validate_split
+from utils.dataset_utils import validate_split, wandb_isolated_dirs
 
 import yaml
 
@@ -169,13 +168,7 @@ def register_in_wandb(
     """Upload combined dataset directory to W&B. W&B artifact entries are declared as lineage inputs."""
     import wandb
 
-    # Redirect W&B artifact cache to a temp dir so ~/.cache/wandb/artifacts
-    # does not accumulate large dataset files after each upload.
-    _prev_cache = os.environ.get("WANDB_CACHE_DIR")
-    _tmp_cache = tempfile.mkdtemp(prefix="wandb_cache_")
-    os.environ["WANDB_CACHE_DIR"] = _tmp_cache
-
-    try:
+    with wandb_isolated_dirs():
         _do_register_in_wandb(
             wandb=wandb,
             output_dir=output_dir,
@@ -187,12 +180,6 @@ def register_in_wandb(
             wandb_collection=wandb_collection,
             wandb_org=wandb_org,
         )
-    finally:
-        shutil.rmtree(_tmp_cache, ignore_errors=True)
-        if _prev_cache is not None:
-            os.environ["WANDB_CACHE_DIR"] = _prev_cache
-        else:
-            os.environ.pop("WANDB_CACHE_DIR", None)
 
 
 def _do_register_in_wandb(

--- a/scripts/combine_datasets.py
+++ b/scripts/combine_datasets.py
@@ -270,63 +270,61 @@ def combine_datasets(
     if register_wandb and not wandb_entity:
         raise ValueError("--wandb-entity is required when --wandb is set.")
 
-    # --- Resolve entries: download W&B refs, keep local paths as-is ---
-    local_dirs: list[str] = []
-    wandb_refs: list[str] = []
-    tmp_download_dirs: list[str] = []
-
-    for entry in datasets:
-        if is_wandb_ref(entry):
-            if not download_dir:
-                print(f"No --download-dir set, using W&B artifact cache.")
-            print(f"Downloading artifact '{entry}'...")
-            local_path, tmp_parent = download_artifact(entry, download_dir)
-            print(f"  → {local_path}")
-            local_dirs.append(local_path)
-            wandb_refs.append(entry)
-            if tmp_parent:
-                tmp_download_dirs.append(tmp_parent)
-        else:
-            local_dirs.append(entry)
-
     # Resolve output directory
     if not output_dir:
         output_dir = tempfile.mkdtemp()
         print(f"No --output-dir set, using temp dir: {output_dir}")
 
     wandb_collection = wandb_collection or Path(output_dir).name
-
-    # --- Read and validate ---
-    print(f"\nReading {len(local_dirs)} dataset(s)...")
-    yamls: list[tuple[Path, dict]] = []
-    for d in local_dirs:
-        yaml_path = Path(d) / "dataset.yaml"
-        if not yaml_path.exists():
-            raise FileNotFoundError(f"dataset.yaml not found in '{d}'")
-        yamls.append((Path(d), yaml.safe_load(yaml_path.read_text(encoding="utf-8"))))
-        print(f"  loaded {yaml_path}")
-
-    classes = validate_classes(yamls)
-    print(f"  classes consistent across all datasets: {classes}")
-
-    # --- Copy images and labels ---
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
 
+    # --- Download, copy, and immediately cleanup each dataset in turn ---
+    local_dirs: list[str] = []
+    wandb_refs: list[str] = []
+    classes = None
     has_train, has_val = False, False
-    print(f"\nCopying dataset files to {output_dir}...")
-    for i, (dataset_dir, y) in enumerate(yamls):
+
+    print(f"\nProcessing {len(datasets)} dataset(s)...")
+    for i, entry in enumerate(datasets):
+        if is_wandb_ref(entry):
+            if not download_dir:
+                print(f"  No --download-dir set, downloading to /tmp.")
+            print(f"  [{i}] Downloading artifact '{entry}'...")
+            local_path, tmp_parent = download_artifact(entry, download_dir)
+            print(f"      → {local_path}")
+            wandb_refs.append(entry)
+        else:
+            local_path, tmp_parent = entry, None
+
+        local_dirs.append(local_path)
+
+        yaml_path = Path(local_path) / "dataset.yaml"
+        if not yaml_path.exists():
+            raise FileNotFoundError(f"dataset.yaml not found in '{local_path}'")
+        y = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+        print(f"  [{i}] loaded {yaml_path}")
+
+        # Validate classes incrementally against the first dataset
+        dataset_names = names_as_list(y["names"])
+        if classes is None:
+            classes = y["names"]
+        elif tuple(names_as_list(classes)) != tuple(dataset_names):
+            raise ValueError(
+                f"Class mismatch in dataset {i} ('{local_path}'):\n"
+                f"  expected : {names_as_list(classes)}\n"
+                f"  got      : {dataset_names}"
+            )
+
         prefix = f"d{i}"
-        print(f"  dataset {i}: {dataset_dir}")
-        if copy_split(dataset_dir, y, "train", output_path, prefix):
+        if copy_split(Path(local_path), y, "train", output_path, prefix):
             has_train = True
-        if copy_split(dataset_dir, y, "val", output_path, prefix):
+        if copy_split(Path(local_path), y, "val", output_path, prefix):
             has_val = True
 
-    # --- Cleanup temp download dirs (no longer needed after copy) ---
-    for d in tmp_download_dirs:
-        shutil.rmtree(d, ignore_errors=True)
-    tmp_download_dirs.clear()
+        if tmp_parent:
+            shutil.rmtree(tmp_parent, ignore_errors=True)
+            print(f"  [{i}] temp download dir removed")
 
     # --- Validate ---
     print("  validating combined dataset...")

--- a/scripts/combine_datasets.py
+++ b/scripts/combine_datasets.py
@@ -23,7 +23,7 @@ Usage (W&B artifacts — no local setup needed):
 python combine_datasets.py \\
   --datasets "sea-ai/dataset-registry/DATASET_A:v0" "sea-ai/dataset-registry/DATASET_B:v1" \\
   --wandb --wandb-entity sea-ai --wandb-collection "my-combined-dataset"
-  # artifacts are downloaded to a temp dir automatically
+  # artifacts are downloaded to a /tmp temp dir, W&B cache skipped
 
 Usage (mixed):
 python combine_datasets.py \\
@@ -31,7 +31,7 @@ python combine_datasets.py \\
   --wandb --wandb-entity sea-ai --wandb-collection "my-combined-dataset"
 
   # --output-dir "/mnt/datasets/COMBINED"  → where the combined dataset is written (default: temp dir)
-  # --download-dir "/mnt/datasets"  → where W&B artifacts are downloaded (default: temp dir)
+  # --download-dir "/mnt/datasets"  → where W&B artifacts are downloaded (default: /tmp, cache skipped)
   # --wandb-org sea-ai-org  → also links to the Dataset Registry
   # W&B versions artifacts by content hash: a new version is only created when the combined files differ from the previous upload
   # A description will be prompted interactively and is required to proceed.
@@ -77,20 +77,24 @@ def validate_classes(yamls: list[tuple[Path, dict]]) -> list[str]:
 def download_artifact(ref: str, download_dir: str | None) -> str:
     """Download a W&B artifact and return its local path.
 
-    If *download_dir* is None the artifact is downloaded to the W&B cache
-    (``~/.cache/wandb/artifacts/``) and the cached path is returned directly,
-    avoiding a second copy on disk.  If *download_dir* is given the artifact
-    is placed under ``<download_dir>/<artifact_name>/`` as before.
+    The W&B cache is always skipped (skip_cache=True). If *download_dir* is
+    None the artifact is placed under a fresh temp directory in /tmp.
+    If *download_dir* is given the artifact is placed under
+    ``<download_dir>/<artifact_name>/``.
     """
     import wandb
 
+    artifact_name = ref.split("/")[-1].split(":")[0]
     api = wandb.Api()
     artifact = api.artifact(ref)
+
     if download_dir is None:
-        return artifact.download()
-    artifact_name = ref.split("/")[-1].split(":")[0]
+        dest = str(Path(tempfile.mkdtemp(dir="/tmp", prefix="wandb_")) / artifact_name)
+        artifact.download(root=dest, skip_cache=True)
+        return dest
+
     dest = str(Path(download_dir) / artifact_name)
-    artifact.download(root=dest)
+    artifact.download(root=dest, skip_cache=True)
     return dest
 
 
@@ -355,7 +359,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--download-dir",
         default=None,
-        help="Directory to download W&B artifacts into. Defaults to a temp directory if any entry in --datasets is a W&B artifact ref.",
+        help="Directory to download W&B artifacts into. Defaults to a /tmp temp directory (W&B cache skipped).",
     )
 
     # Weights & Biases

--- a/scripts/fo_to_yolo.py
+++ b/scripts/fo_to_yolo.py
@@ -48,7 +48,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import yaml
 from fiftyone import ViewField as F
-from utils.dataset_utils import validate_split
+from utils.dataset_utils import validate_split, wandb_isolated_dirs
 
 
 # ---------------------------------------------------------------------------
@@ -225,6 +225,19 @@ def register_in_wandb(
     """Upload dataset artifact to W&B. If wandb_org is provided, also link to the Dataset Registry."""
     import wandb
 
+    with wandb_isolated_dirs():
+        _do_register_in_wandb(wandb, export_dir, dataset_name, params, wandb_entity, wandb_collection, wandb_org)
+
+
+def _do_register_in_wandb(
+    wandb,
+    export_dir: str,
+    dataset_name: str,
+    params: dict,
+    wandb_entity: str,
+    wandb_collection: str,
+    wandb_org: str | None,
+) -> None:
     # A run is required by W&B to upload artifacts. We use a fixed internal
     # project so it never appears alongside training experiments.
     with wandb.init(

--- a/scripts/fo_to_yolo.py
+++ b/scripts/fo_to_yolo.py
@@ -386,6 +386,8 @@ def export_dataset(cfg: ExportConfig) -> None:
     tmp_name = f"tmp_{cfg.dataset_name}"
     if cfg.use_16bit:
         LOGGER.info("  switching filepaths to 16-bit PNG...")
+        if fo.dataset_exists(tmp_name):
+            fo.delete_dataset(tmp_name)
         export = export.clone(tmp_name)
         filepaths = [
             fp.replace("8Bit", "16Bit").replace("jpg", "png")

--- a/utils/dataset_utils.py
+++ b/utils/dataset_utils.py
@@ -42,15 +42,13 @@ def wandb_isolated_dirs():
     """
     prev_cache = os.environ.get("WANDB_CACHE_DIR")
     prev_data = os.environ.get("WANDB_DATA_DIR")
-    tmp_cache = tempfile.mkdtemp(prefix="wandb_cache_")
-    tmp_data = tempfile.mkdtemp(prefix="wandb_data_")
-    os.environ["WANDB_CACHE_DIR"] = tmp_cache
-    os.environ["WANDB_DATA_DIR"] = tmp_data
+    tmp_dir = tempfile.mkdtemp(prefix="wandb_tmp_")
+    os.environ["WANDB_CACHE_DIR"] = tmp_dir
+    os.environ["WANDB_DATA_DIR"] = tmp_dir
     try:
         yield
     finally:
-        shutil.rmtree(tmp_cache, ignore_errors=True)
-        shutil.rmtree(tmp_data, ignore_errors=True)
+        shutil.rmtree(tmp_dir, ignore_errors=True)
         if prev_cache is not None:
             os.environ["WANDB_CACHE_DIR"] = prev_cache
         else:

--- a/utils/dataset_utils.py
+++ b/utils/dataset_utils.py
@@ -1,4 +1,8 @@
 import logging
+import os
+import shutil
+import tempfile
+from contextlib import contextmanager
 from pathlib import Path
 
 LOGGER = logging.getLogger(__name__)
@@ -26,3 +30,32 @@ def validate_split(out_dir: Path, split: str) -> None:
             f"Image/label count mismatch in split '{split}': {n_images} images vs {n_labels} labels"
         )
     LOGGER.info(f"  {split}: {n_images} images, {n_labels} labels — OK")
+
+
+@contextmanager
+def wandb_isolated_dirs():
+    """Context manager that redirects W&B cache and data dirs to temp directories.
+
+    Prevents ~/.cache/wandb/artifacts and ~/.local/share/wandb/artifacts from
+    accumulating large dataset files after each upload. Both temp dirs are
+    deleted when the context exits, and the original env vars are restored.
+    """
+    prev_cache = os.environ.get("WANDB_CACHE_DIR")
+    prev_data = os.environ.get("WANDB_DATA_DIR")
+    tmp_cache = tempfile.mkdtemp(prefix="wandb_cache_")
+    tmp_data = tempfile.mkdtemp(prefix="wandb_data_")
+    os.environ["WANDB_CACHE_DIR"] = tmp_cache
+    os.environ["WANDB_DATA_DIR"] = tmp_data
+    try:
+        yield
+    finally:
+        shutil.rmtree(tmp_cache, ignore_errors=True)
+        shutil.rmtree(tmp_data, ignore_errors=True)
+        if prev_cache is not None:
+            os.environ["WANDB_CACHE_DIR"] = prev_cache
+        else:
+            os.environ.pop("WANDB_CACHE_DIR", None)
+        if prev_data is not None:
+            os.environ["WANDB_DATA_DIR"] = prev_data
+        else:
+            os.environ.pop("WANDB_DATA_DIR", None)


### PR DESCRIPTION
## What?

Previously, downloading W&B artifacts wrote files to both `~/.cache/wandb/artifacts/obj/md5/` (content-addressable blobs) and a fresh `/tmp` directory on every run. After this change, the W&B cache is fully bypassed (`skip_cache=True`) and artifacts are downloaded directly to `/tmp`, leaving `~/.cache/wandb/` untouched.

## Why?

Storage efficiency: the W&B cache stores every artifact file as a hashed blob under `~/.cache/wandb/artifacts/obj/md5/`, accumulating many files over time without automatic cleanup. For machines running the combine pipeline repeatedly this led to unbounded growth of the cache directory.

## How?

`artifact.download(root=dest, skip_cache=True)` is now used in all code paths inside `download_artifact`:

| Scenario | Before | After |
|---|---|---|
| No `--download-dir` | Downloaded to `./artifacts/<name>/` + cache written to `~/.cache/wandb/` | Downloaded to `/tmp/wandb_<uuid>/<name>/`, no cache written |
| `--download-dir` given | Downloaded to `<dir>/<name>/` + cache written to `~/.cache/wandb/` | Downloaded to `<dir>/<name>/`, no cache written |

## Backout plan

Revert by removing `skip_cache=True` from both `artifact.download()` calls in `download_artifact` and restoring the default download root when no `--download-dir` is given. No registry state or artifact data is affected.

## Testing

Run the script with a W&B artifact ref and no `--download-dir`:

```bash
python scripts/combine_datasets.py \
  --datasets "sea-ai/dataset-registry/DATASET_A:v0" \
  --wandb --wandb-entity sea-ai --wandb-collection test-combined
```

**Expected:** artifact materialises under `/tmp/wandb_<uuid>/DATASET_A/`. Confirm no new blobs were written to the cache:

```bash
# Record cache state before
find ~/.cache/wandb/artifacts/obj/md5 | wc -l   # note count

# Run the script ...

# Check cache state after — count should be unchanged
find ~/.cache/wandb/artifacts/obj/md5 | wc -l
```
