### PR TITLE
Superseded: Remove PyTorch model I/O hooks

### DIFF
--- a/export_custom.py
+++ b/export_custom.py
@@ -43,7 +43,7 @@ def export_model_to_onnx(
     Generic export logic for both YOLO and AHOY models.
 
     Args:
-        model: The model to export (must have prepare_for_export and register_io_hooks methods)
+        model: The model to export (must have prepare_for_export method and pre/post in forward)
         imgsz: Image size as (height, width) tuple
         batch_size: Batch size for the model
         fname: Output filename for the ONNX model
@@ -57,13 +57,12 @@ def export_model_to_onnx(
     if not fname:
         input_size = f"{imgsz[0]}x{imgsz[1]}"
         base = type(model).__name__.lower()
-        if isinstance(model.obj_det_weights, list) and len(model.obj_det_weights) > 1:
+        if hasattr(model, "_det_models") and len(model._det_models) > 1:
             base = f"{base}ensemble"
         fname = f"{base}_b{batch_size}_sz{input_size}.onnx"
     LOGGER.info(f"🚀 Exporting model {type(model).__name__} to {fname}...")
 
     model.prepare_for_export(dynamic=dynamic)
-    model.register_io_hooks()  # inp: uint8 -> fp32/fp16 / 255.0, out: fp16 -> fp32
 
     image = torch.zeros((batch_size, 3, imgsz[0], imgsz[1]), device=model.device).byte()  # B, C, H, W
     image = image.float() if trt7_compatible else image

--- a/models/custom.py
+++ b/models/custom.py
@@ -351,7 +351,7 @@ class ObjectsModel(BaseModel):
 class YOLO(nn.Module):
     """YOLO model: one or more detection weights, same input, single output.
 
-    - One weight: single detection model with preprocessing/postprocessing hooks.
+    - One weight: single detection model.
     - Two or more weights: ensemble (same input to all, merged output with shared class space).
     """
 
@@ -383,7 +383,6 @@ class YOLO(nn.Module):
         self.stride = self.obj_det.stride
         self.imgsz = transform_sz(imgsz)
         self.infsz = transform_sz(imgsz) if infsz is None else transform_sz(infsz)
-        self.hooks = {}
         self.transform, self.ratio_pad = self.get_transform(imgsz, infsz)
 
         models_id2name: List[Dict[int, str]] = [m.names for m in self._det_models]
@@ -399,11 +398,33 @@ class YOLO(nn.Module):
         if len(self._det_models) > 1:
             LOGGER.info(f"YOLO ensemble: {len(self._det_models)} models, merged classes={self.names}")
 
+    def _preprocess(self, x: torch.Tensor) -> torch.Tensor:
+        """uint8 input -> optional resize/pad -> fp16/fp32 -> scale to [0, 1]."""
+        if self.transform is not None:
+            x = x.float()
+            x = self.transform(x)
+        x = x.half() if self.fp16 else x.float()
+        return x / 255
+
+    def _postprocess_det(
+        self, x: torch.Tensor, *, xywh: bool = False, clip: bool = True
+    ) -> torch.Tensor:
+        """Scale boxes back to original image size and cast to float. For OBB/horizons use xywh=True, clip=False."""
+        if self.ratio_pad is not None:
+            x = scale_boxes(
+                self.infsz, x, self.imgsz, ratio_pad=self.ratio_pad, xywh=xywh, clip=clip
+            )
+        if self.fp16:
+            x = x.float()
+        return x
+
     def forward(self, x, profile=False, visualize=False):
-        """Run all models on input and merge their detections into one tensor."""
+        """Preprocess -> run detection model(s) -> merge if ensemble -> postprocess."""
+        x = self._preprocess(x)
         preds = [m(x, profile, visualize) for m in self._det_models]
         det_tensors = [p[0] if isinstance(p, tuple) else p for p in preds]
-        return (det_tensors[0],) if len(det_tensors) == 1 else (self._merge_detections(det_tensors),)
+        det = det_tensors[0] if len(det_tensors) == 1 else self._merge_detections(det_tensors)
+        return (self._postprocess_det(det),)
 
     def _merge_detections(self, det_tensors: List[torch.Tensor]) -> torch.Tensor:
         """Merge per-model detection tensors into one with class columns remapped to shared space.
@@ -435,29 +456,6 @@ class YOLO(nn.Module):
         )
         out = torch.gather(stacked, dim=3, index=gather_index)
         return out.reshape(batch, n_models * max_dets, n_shared_cols)
-
-    def register_preprocessing_hook(self):
-        """Register hooks to convert uint8 to fp16/fp32 and scale by 1/255 before forward pass."""
-        if "preprocessing" in self.hooks:
-            return
-        self.hooks["preprocessing"] = self.register_forward_pre_hook(self._preprocessing_hook)
-
-    def register_postprocessing_hook(self):
-        """Register hooks to convert half to float precision after forward pass."""
-        if "postprocessing" in self.hooks:
-            return
-        self.hooks["postprocessing"] = self.register_forward_hook(self._postprocessing_hook)
-
-    def register_io_hooks(self):
-        """Register hooks for input and output processing."""
-        self.register_preprocessing_hook()
-        self.register_postprocessing_hook()
-
-    def remove_hooks(self):
-        """Remove hooks."""
-        for _, hook in self.hooks.items():
-            hook.remove()
-        self.hooks.clear()
 
     @staticmethod
     def get_transform(imgsz: Tuple[int, int], infsz: Optional[Tuple[int, int]] = None):
@@ -517,38 +515,6 @@ class YOLO(nn.Module):
 
         return pad_left, pad_right, pad_top, pad_bottom
 
-    @staticmethod
-    def _preprocessing_hook(module, inputs):
-        """Add preprocessing operations to be part of the model."""
-
-        def _preprocess(x: torch.Tensor):
-            if len(x.shape) < 1:
-                return x
-            if module.transform is not None:
-                x = x.float()
-                x = module.transform(x)
-            x = x.half() if module.fp16 else x.float()
-            x = x / 255  # 0-255 to 0.0-1.0
-            return x
-
-        return tuple(_preprocess(inp) for inp in inputs)
-
-    @staticmethod
-    def _postprocessing_hook(module, _inputs, outputs):
-        """Convert outputs to float (if needed) and scale back boxes if transform was applied."""
-
-        def _to_float(x):
-            return x.float() if module.fp16 else x
-
-        # Scale back boxes if transform was applied
-        if module.ratio_pad is not None:
-            outputs = (scale_boxes(module.infsz, outputs[0], module.imgsz, ratio_pad=module.ratio_pad),) + outputs[1:]
-
-        # Convert first item (detection outputs) to float if needed
-        outputs = (_to_float(outputs[0]),) + outputs[1:]
-
-        return outputs
-
     def prepare_for_export(self, dynamic: bool = False):
         """Prepare model(s) for export."""
         LOGGER.info(f"✨ Preparing {self.__class__.__name__} for export...")
@@ -560,7 +526,7 @@ class AHOY(YOLO):
     """Base class for AHOY models that extends YOLO with horizon detection.
 
     AHOY: **A** **H**orizon and **O**bject detection **Y**OLO-based model.
-    Inherits preprocessing, hook management, and transform logic from YOLO.
+    Inherits preprocessing, transform logic, and detection postprocessing from YOLO.
     """
 
     def __new__(cls, hor_det_weights: str, **kwargs):
@@ -637,21 +603,15 @@ class AHOY(YOLO):
         """Forward pass through models."""
         raise NotImplementedError("Subclasses should implement this method")
 
-    @staticmethod
-    def _postprocessing_hook(module, inputs, outputs):
-        """Convert outputs to float (if needed) and apply softmax to logits."""
-        raise NotImplementedError("Subclasses should implement this method")
-
     def prepare_for_export(self, dynamic: bool = False):
-        """Prepare both object detection and horizon detection models for export."""
-        LOGGER.info(f"✨ Preparing {self.obj_det.__class__.__name__} for export...")
-        self.obj_det.prepare_for_export(dynamic)
+        """Prepare all detection models and horizon model for export."""
+        super().prepare_for_export(dynamic)
         LOGGER.info(f"✨ Preparing {self.hor_det.__class__.__name__} for export...")
         self.hor_det.prepare_for_export(dynamic)
 
 
 class AHOYv1(AHOY):
-    """A H-orizon O-bject detection Y-OLOv5 (object detection with yolov5)."""
+    """AHOYv1: object detection + horizon classification (pitch & theta logits)."""
 
     def load_hor_det(
         self, hor_det_weights: str, device: Union[str, torch.device] = None, fp16: bool = False, fuse: bool = True
@@ -660,40 +620,21 @@ class AHOYv1(AHOY):
         return HorizonModel(hor_det_weights, device=device, fp16=fp16, fuse=fuse)
 
     def forward(self, x, profile=False, visualize=False):
-        """Forward pass through models."""
+        x = self._preprocess(x)
         objects = self.obj_det(x, profile, visualize)
         pitch, theta = self.hor_det(x, profile, visualize)
-        return objects, pitch, theta
 
-    @staticmethod
-    def _postprocessing_hook(module, inputs, outputs):
-        """Convert outputs to float (if needed) and apply softmax to logits."""
-
-        def _to_float(x):
-            return x.float() if module.fp16 else x
-
-        # ahoy outputs: (tuple(Tensor, ...), Tensor, Tensor)
-        first_tuple, second_item, third_item = outputs
-
-        # Scale back boxes if transform was applied
-        if module.ratio_pad is not None:
-            first_tuple = (
-                scale_boxes(module.infsz, first_tuple[0], module.imgsz, ratio_pad=module.ratio_pad),
-            ) + first_tuple[1:]
-
-        # Only convert the first item of the first tuple (the detection outputs)
-        first_tuple = (_to_float(first_tuple[0]),) + first_tuple[1:]
-
-        # second and third items are classification logits
-        second_item = second_item.softmax(-1)  # batch dim
-        third_item = third_item.softmax(-1)  # batch dim
-
-        # Reconstruct the overall output
-        return (first_tuple, _to_float(second_item), _to_float(third_item))
+        det = self._postprocess_det(objects[0])
+        pitch = pitch.softmax(-1)
+        theta = theta.softmax(-1)
+        if self.fp16:
+            pitch = pitch.float()
+            theta = theta.float()
+        return (det,) + objects[1:], pitch, theta
 
 
 class AHOYv2(AHOY):
-    """A H-orizon O-bject detection Y-OLOv5 (object detection with yolov5)."""
+    """AHOYv2: object detection + OBB-based horizon detection."""
 
     def load_hor_det(
         self, hor_det_weights: str, device: Union[str, torch.device] = None, fp16: bool = False, fuse: bool = True
@@ -702,39 +643,15 @@ class AHOYv2(AHOY):
         return OBBModel(hor_det_weights, device=device, fp16=fp16, fuse=fuse)
 
     def forward(self, x, profile=False, visualize=False):
-        """Forward pass through models."""
+        x = self._preprocess(x)
         objects = self.obj_det(x, profile, visualize)
         horizons = self.hor_det(x)
-        return objects, horizons
 
-    @staticmethod
-    def _postprocessing_hook(module, inputs, outputs):
-        """Convert outputs to float (if needed) and apply softmax to logits."""
-
-        def _to_float(x):
-            return x.float() if module.fp16 else x
-
-        # first_tuple: (tuple(Tensor, ...), Tensor)
-        # second_tuple: Tensor
-        first_tuple, second_item = outputs
-
-        # transpose to (batch_size, num_boxes, num_classes)
-        second_item = second_item.transpose(1, 2)
-
-        # Scale back boxes if transform was applied
-        if module.ratio_pad is not None:
-            first_tuple = (
-                scale_boxes(module.infsz, first_tuple[0], module.imgsz, ratio_pad=module.ratio_pad),
-            ) + first_tuple[1:]
-            second_item = scale_boxes(
-                module.infsz, second_item, module.imgsz, ratio_pad=module.ratio_pad, xywh=True, clip=False
-            )
-
-        # Only convert the first item of the first tuple (the detection outputs)
-        first_tuple = (_to_float(first_tuple[0]),) + first_tuple[1:]
-        second_item = _to_float(second_item)
-
-        return (first_tuple, second_item)
+        det = self._postprocess_det(objects[0])
+        horizons = self._postprocess_det(
+            horizons.transpose(1, 2), xywh=True, clip=False
+        )
+        return (det,) + objects[1:], horizons
 
 
 class DAN(nn.Module):
@@ -771,11 +688,6 @@ class DAN(nn.Module):
         out_a = self.model_a(x_1, profile, visualize)
         out_b = self.model_b(x_2, profile, visualize)
         return out_a, out_b
-
-    def register_io_hooks(self):
-        """Register hooks for input and output processing."""
-        self.model_a.register_io_hooks()
-        self.model_b.register_io_hooks()
 
 
 def _find_cutoff(model):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Superseded

This stacked PR was created with `cursor/simplify-model-export-eb51` as its base. The hook-removal work has been recreated as an independent PR against `develop` instead:

- #42 Remove PyTorch model I/O hooks

Please review #42 for the independent split.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44186d5e-b26c-4adf-b4bb-7646ff9beb51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44186d5e-b26c-4adf-b4bb-7646ff9beb51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

