### PR TITLE
Fix ONNX export opset version reverted to 12

### DIFF
--- a/export_custom.py
+++ b/export_custom.py
@@ -78,7 +78,7 @@ def export_model_to_onnx(
         file=Path(fname),
         dynamic=dynamic,
         simplify=simplify,
-        opset=17,
+        opset=12,
     )
 
     return result

--- a/export_custom.py
+++ b/export_custom.py
@@ -78,7 +78,7 @@ def export_model_to_onnx(
         file=Path(fname),
         dynamic=dynamic,
         simplify=simplify,
-        opset=18,
+        opset=17,
     )
 
     return result


### PR DESCRIPTION
## What?

Reverts the ONNX export opset version in `export_custom.py` back to 12. The opset was accidentally bumped to 18, which caused compiled models to stop working.

## Why?

The opset version was accidentally increased to 18, breaking compatibility with our compiled models. Reverting to 12 restores correct behavior.

## How?

Single-line change in `export_custom.py`: `opset=18` → `opset=12`.

## Testing

Models compiled with opset 12 load and run correctly. The regression introduced by opset 18 is resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted ONNX export operator set version to improve compatibility across different runtime versions and hardware configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->