### PR TITLE
SEA-897 Modernize CoreML export and fix NMS pipeline export

### DIFF
--- a/export.py
+++ b/export.py
@@ -1268,7 +1268,13 @@ def pipeline_coreml(model, im, file, names, y, mlmodel, prefix=colorstr("CoreML 
     nx, ny = spec.description.input[0].type.imageType.width, spec.description.input[0].type.imageType.height
     _na, nc = out0_shape
     # na, nc = out0.type.multiArrayType.shape  # number anchors, classes
-    assert len(names) == nc, f"{len(names)} names found for nc={nc}"  # check
+    # nc may be padded to a multiple of 80 by iOSModel (mlprogram workaround); build padded names to match
+    nc_actual = len(names)
+    if nc_actual != nc:
+        LOGGER.warning(f"{prefix} class count mismatch: {nc_actual} names vs nc={nc} (padding applied)")
+    padded_names = dict(names)
+    for i in range(nc_actual, nc):
+        padded_names[i] = f"_pad_{i}"
 
     # Define output shapes (missing)
     out0.type.multiArrayType.shape[:] = out0_shape  # (3780, 80)
@@ -1328,7 +1334,7 @@ def pipeline_coreml(model, im, file, names, y, mlmodel, prefix=colorstr("CoreML 
     nms.iouThreshold = 0.45
     nms.confidenceThreshold = 0.25
     nms.pickTop.perClass = True
-    nms.stringClassLabels.vector.extend(names.values())
+    nms.stringClassLabels.vector.extend(padded_names.values())
     nms_model = ct.models.MLModel(nms_spec)
 
     # 4. Pipeline models together

--- a/export.py
+++ b/export.py
@@ -9,7 +9,7 @@ TorchScript                 | `torchscript`                 | yolov5s.torchscrip
 ONNX                        | `onnx`                        | yolov5s.onnx
 OpenVINO                    | `openvino`                    | yolov5s_openvino_model/
 TensorRT                    | `engine`                      | yolov5s.engine
-CoreML                      | `coreml`                      | yolov5s.mlmodel
+CoreML                      | `coreml`                      | yolov5s.mlpackage
 TensorFlow SavedModel       | `saved_model`                 | yolov5s_saved_model/
 TensorFlow GraphDef         | `pb`                          | yolov5s.pb
 TensorFlow Lite             | `tflite`                      | yolov5s.tflite
@@ -30,7 +30,7 @@ Inference:
                                  yolov5s.onnx               # ONNX Runtime or OpenCV DNN with --dnn
                                  yolov5s_openvino_model     # OpenVINO
                                  yolov5s.engine             # TensorRT
-                                 yolov5s.mlmodel            # CoreML (macOS-only)
+                                 yolov5s.mlpackage          # CoreML (macOS-only)
                                  yolov5s_saved_model        # TensorFlow SavedModel
                                  yolov5s.pb                 # TensorFlow GraphDef
                                  yolov5s.tflite             # TensorFlow Lite
@@ -625,6 +625,11 @@ def export_coreml(model, im, file, int8, half, nms, mlmodel, prefix=colorstr("Co
                 ct_model = ct.models.neural_network.quantization_utils.quantize_weights(ct_model, bits, mode)
         elif bits == 8:
             # linear quantization (INT8) — better ANE/GPU utilization than palettization for mlpackage
+            # coremltools.optimize.coreml requires coremltools >= 7.0
+            from packaging.version import Version
+
+            if Version(ct.__version__) < Version("7.0"):
+                raise RuntimeError(f"INT8 quantization for .mlpackage requires coremltools >= 7.0 (found {ct.__version__})")
             import coremltools.optimize.coreml as cto
 
             op_config = cto.OpLinearQuantizerConfig(mode="linear_symmetric", dtype="int8", weight_threshold=512)

--- a/export.py
+++ b/export.py
@@ -94,12 +94,13 @@ MACOS = platform.system() == "Darwin"  # macOS environment
 class iOSModel(torch.nn.Module):
     """An iOS-compatible wrapper for YOLOv5 models that normalizes input images based on their dimensions."""
 
-    def __init__(self, model, im):
+    def __init__(self, model, im, mlprogram=False):
         """Initializes an iOS compatible model with normalization based on image dimensions.
 
         Args:
             model (torch.nn.Module): The PyTorch model to be adapted for iOS compatibility.
             im (torch.Tensor): An input tensor representing a batch of images with shape (B, C, H, W).
+            mlprogram (bool): Whether exporting as mlprogram (.mlpackage). Enables class-count padding workaround.
 
         Returns:
             None: This method does not return any value.
@@ -113,6 +114,7 @@ class iOSModel(torch.nn.Module):
         _b, _c, h, w = im.shape  # batch, channel, height, width
         self.model = model
         self.nc = model.nc  # number of classes
+        self.mlprogram = mlprogram
         if w == h:
             self.normalize = 1.0 / w
         else:
@@ -138,6 +140,11 @@ class iOSModel(torch.nn.Module):
             ```
         """
         xywh, conf, cls = self.model(x)[0].squeeze().split((4, 1, self.nc), 1)
+        if self.mlprogram and self.nc % 80 != 0:
+            # mlprogram NMS requires class count to be a multiple of 80
+            # https://github.com/ultralytics/ultralytics/issues/22309
+            pad = int(((self.nc + 79) // 80) * 80) - self.nc
+            cls = torch.nn.functional.pad(cls, (0, pad, 0, 0), "constant", 0)
         return cls * conf, xywh * self.normalize  # confidence (3780, 80), coordinates (3780, 4)
 
 
@@ -583,7 +590,8 @@ def export_coreml(model, im, file, int8, half, nms, mlmodel, prefix=colorstr("Co
         ```
 
     Notes:
-        The exported CoreML model will be saved with a .mlmodel extension.
+        The exported CoreML model is saved as .mlpackage by default (mlprogram backend, recommended).
+        Pass mlmodel=True to export the legacy .mlmodel format (neuralnetwork backend).
         Quantization is supported only on macOS.
     """
     check_requirements("coremltools")
@@ -599,7 +607,7 @@ def export_coreml(model, im, file, int8, half, nms, mlmodel, prefix=colorstr("Co
         convert_to = "mlprogram"
         precision = ct.precision.FLOAT16 if half else ct.precision.FLOAT32
     if nms:
-        model = iOSModel(model, im)
+        model = iOSModel(model, im, mlprogram=not mlmodel)
     ts = torch.jit.trace(model, im, strict=False)  # TorchScript model
     ct_model = ct.convert(
         ts,
@@ -616,9 +624,12 @@ def export_coreml(model, im, file, int8, half, nms, mlmodel, prefix=colorstr("Co
                 )  # suppress numpy==1.20 float warning, fixed in coremltools==7.0
                 ct_model = ct.models.neural_network.quantization_utils.quantize_weights(ct_model, bits, mode)
         elif bits == 8:
-            op_config = ct.optimize.coreml.OpPalettizerConfig(mode=mode, nbits=bits, weight_threshold=512)
-            config = ct.optimize.coreml.OptimizationConfig(global_config=op_config)
-            ct_model = ct.optimize.coreml.palettize_weights(ct_model, config)
+            # linear quantization (INT8) — better ANE/GPU utilization than palettization for mlpackage
+            import coremltools.optimize.coreml as cto
+
+            op_config = cto.OpLinearQuantizerConfig(mode="linear_symmetric", dtype="int8", weight_threshold=512)
+            config = cto.OptimizationConfig(global_config=op_config)
+            ct_model = cto.linear_quantize_weights(ct_model, config)
     ct_model.save(f)
     return f, ct_model
 
@@ -1285,7 +1296,7 @@ def pipeline_coreml(model, im, file, names, y, mlmodel, prefix=colorstr("CoreML 
 
     # 3. Create NMS protobuf
     nms_spec = ct.proto.Model_pb2.Model()
-    nms_spec.specificationVersion = 5
+    nms_spec.specificationVersion = spec.specificationVersion  # inherit from model to support both mlmodel and mlpackage
     for i in range(2):
         decoder_output = model._spec.description.output[i].SerializeToString()
         nms_spec.description.input.add()
@@ -1338,7 +1349,7 @@ def pipeline_coreml(model, im, file, names, y, mlmodel, prefix=colorstr("CoreML 
     pipeline.spec.description.output[1].ParseFromString(nms_model._spec.description.output[1].SerializeToString())
 
     # Update metadata
-    pipeline.spec.specificationVersion = 5
+    pipeline.spec.specificationVersion = spec.specificationVersion  # inherit from model
     pipeline.spec.description.metadata.versionString = "https://github.com/ultralytics/yolov5"
     pipeline.spec.description.metadata.shortDescription = "https://github.com/ultralytics/yolov5"
     pipeline.spec.description.metadata.author = "glenn.jocher@ultralytics.com"
@@ -1603,7 +1614,7 @@ def parse_opt(known=False):
     parser.add_argument("--dynamic", action="store_true", help="ONNX/TF/TensorRT: dynamic axes")
     parser.add_argument("--cache", type=str, default="", help="TensorRT: timing cache file path")
     parser.add_argument("--simplify", action="store_true", help="ONNX: simplify model")
-    parser.add_argument("--mlmodel", action="store_true", help="CoreML: Export in *.mlmodel format")
+    parser.add_argument("--mlmodel", action="store_true", help="CoreML: export legacy *.mlmodel (neuralnetwork) instead of *.mlpackage (mlprogram, default)")
     parser.add_argument("--opset", type=int, default=17, help="ONNX: opset version")
     parser.add_argument("--verbose", action="store_true", help="TensorRT: verbose log")
     parser.add_argument("--workspace", type=int, default=4, help="TensorRT: workspace size (GB)")


### PR DESCRIPTION
## What?

Modernizes the CoreML export to use `.mlpackage` (mlprogram) as default and fixes a crash when exporting with `--nms` for models whose class count isn't a multiple of 80.

## Why?

Custom SEA.AI models (e.g. 18 classes) could not be exported with NMS baked in, blocking deployment to iOS/macOS apps. The legacy `.mlmodel` backend also misses out on better ANE/GPU utilization available in mlprogram.

## How?

| | Before | After |
|---|---|---|
| Default format | `.mlmodel` (neuralnetwork) | `.mlpackage` (mlprogram) |
| `--half` | not supported for mlpackage | FP16 precision via `ct.precision.FLOAT16` |
| `--int8` | palettization (kmeans) | linear symmetric quantization |
| `--nms` on custom models | crash | works; confidence output padded to next multiple of 80, real classes first |

> **Note:** when using `--nms`, the `confidence` output shape is `(N, 80)` for models with fewer than 80 classes. Slice `[:, :nc]` on the app side to drop the padding columns.

## Testing

<!-- To be filled in manually. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CoreML export now defaults to mlpackage format; legacy mlmodel format available via export option.

* **Improvements**
  * Optimized quantization method for CoreML INT8 exports.
  * Updated documentation and export help text to reflect new default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->